### PR TITLE
 Fixed #48 by properly persisting scans now

### DIFF
--- a/clouditor-engine-core/src/main/java/io/clouditor/Engine.java
+++ b/clouditor-engine-core/src/main/java/io/clouditor/Engine.java
@@ -158,16 +158,16 @@ public class Engine extends Component {
     this.getService(CertificationService.class).loadImporters();
 
     loadRules();
-    loadScans();
+    initDiscoveryService();
     loadCertifications();
     loadSubscribers();
 
     this.getService(CertificationService.class).updateCertification();
   }
 
-  private void loadScans() {
+  private void initDiscoveryService() {
     var service = this.getService(DiscoveryService.class);
-    service.load();
+    service.init();
   }
 
   public void loadRules() {

--- a/clouditor-engine-core/src/main/java/io/clouditor/credentials/AccountService.java
+++ b/clouditor-engine-core/src/main/java/io/clouditor/credentials/AccountService.java
@@ -102,11 +102,11 @@ public class AccountService {
 
     // since we changed the account (potentially), we need to make sure the scanners associated with
     // this provider re-authenticate properly
-    for (var scan : this.discoveryService.getScans().values()) {
-      var scanner = scan.getScanner();
+    for (var scanner : this.discoveryService.getScanners()) {
+      var info = scanner.getInfo();
 
-      if (scanner.getInitialized() && Objects.equals(scan.getGroup(), provider)) {
-        LOGGER.info("Forcing scanner {} / {} to re-authenticate.", scan.getService(), scan.getId());
+      if (scanner.getInitialized() && Objects.equals(info.group(), provider)) {
+        LOGGER.info("Forcing scanner {} to re-authenticate.", scanner.getId());
         scanner.setInitialized(false);
       }
     }

--- a/clouditor-engine-core/src/main/java/io/clouditor/discovery/DiscoveryService.java
+++ b/clouditor-engine-core/src/main/java/io/clouditor/discovery/DiscoveryService.java
@@ -251,6 +251,10 @@ public class DiscoveryService {
 
     this.scheduler.setCorePoolSize(size);
     LOGGER.info("Adjusting thread pool size to {}", this.scheduler.getCorePoolSize());
+
+    // clean up associated objects
+    this.futures.remove(scan.getId());
+    this.scanners.remove(scan.getId());
   }
 
   public void subscribe(DiscoveryResultSubscriber subscriber) {

--- a/clouditor-engine-core/src/main/java/io/clouditor/discovery/DiscoveryService.java
+++ b/clouditor-engine-core/src/main/java/io/clouditor/discovery/DiscoveryService.java
@@ -29,10 +29,13 @@
 
 package io.clouditor.discovery;
 
+import static com.mongodb.client.model.Filters.eq;
+
 import io.clouditor.events.DiscoveryResultSubscriber;
 import io.clouditor.util.PersistenceManager;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -43,6 +46,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.glassfish.jersey.media.sse.EventOutput;
@@ -62,9 +66,8 @@ public class DiscoveryService {
           new ConfigurationBuilder()
               .addUrls(ClasspathHelper.forPackage(Scanner.class.getPackage().getName()))
               .setScanners(new SubTypesScanner()));
-
-  private Map<String, Scan> scans = new HashMap<>();
   private Map<String, ScheduledFuture<?>> futures = new HashMap<>();
+  private Map<String, Scanner> scanners = new HashMap<>();
 
   private final ScheduledThreadPoolExecutor scheduler =
       (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1);
@@ -76,51 +79,57 @@ public class DiscoveryService {
     LOGGER.info("Initializing {}", this.getClass().getSimpleName());
   }
 
-  public void load() {
-    // TODO: load from database
+  public void init() {
+    var scans = PersistenceManager.getInstance().find(Scan.class);
 
-    // first, load checks from Java via reflections
+    // first, init list of scanner classes from Java via reflections
     var classes =
         REFLECTIONS_SUBTYPE_SCANNER.getSubTypesOf(Scanner.class).stream()
             .filter(
                 clazz -> !Modifier.isAbstract(clazz.getModifiers()) && !clazz.isAnonymousClass())
             .collect(Collectors.toList());
 
-    // loop through all Scanner classes, to make sure a Scan object exists for each class
-    for (var clazz : classes) {
-      try {
-        var constructor = clazz.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        var scan = Scan.fromScanner(constructor.newInstance());
+    // loop through existing scans to make sure that the associated scanner still exists
+    for (var scan : scans) {
+      if (!classes.contains(scan.getScannerClass())) {
+        LOGGER.info(
+            "Scan {} contains old or invalid scanner class {}. Removing entry from database.",
+            scan.getId(),
+            scan.getScannerClass());
 
-        // update database
-        PersistenceManager.getInstance().persist(scan);
-
-        // TODO: do not overwrite custom settings from DB (maybe load db later?)
-        this.scans.put(scan.getId(), scan);
-      } catch (InstantiationException
-          | IllegalAccessException
-          | InvocationTargetException
-          | NoSuchMethodException e) {
-        LOGGER.error("Ignoring instantiate scanner class {}: {}", clazz.getName(), e);
-        continue;
+        PersistenceManager.getInstance().delete(Scan.class, scan.getId());
       }
     }
 
-    LOGGER.info("Loaded {} scans", this.scans.size());
+    // loop through all Scanner classes, to make sure a Scan object exists for each class
+    for (var clazz : classes) {
+      var scan =
+          PersistenceManager.getInstance()
+              .find(Scan.class, eq(Scan.FIELD_SCANNER_CLASS, clazz.getName()))
+              .limit(1)
+              .first();
 
-    // adjust the thread pool
-    this.scheduler.setCorePoolSize(this.scans.size());
-    LOGGER.info("Adjusting thread pool size to {}", this.scheduler.getCorePoolSize());
+      if (scan == null) {
+        // create new scanner object
+        scan = Scan.fromScanner(clazz);
+
+        // update database
+        PersistenceManager.getInstance().persist(scan);
+      }
+    }
   }
 
   public Map<String, Scan> getScans() {
-    return this.scans;
+    return StreamSupport.stream(
+            PersistenceManager.getInstance().find(Scan.class).spliterator(), false)
+        .collect(Collectors.toMap(Scan::getId, scan -> scan));
   }
 
   public void start() {
+    var scans = PersistenceManager.getInstance().find(Scan.class);
+
     // loop through all enabled scans and start them
-    for (var scan : this.scans.values()) {
+    for (var scan : scans) {
       if (scan.isEnabled()) {
         this.startScan(scan);
       }
@@ -128,64 +137,90 @@ public class DiscoveryService {
   }
 
   private void startScan(Scan scan) {
-    var scanner = scan.getScanner();
+    LOGGER.info("Starting scan {}", scan.getId());
 
-    // check, if it is somehow already running, and cancel it
-    var future = this.futures.get(scan.getId());
-    if (future != null) {
-      LOGGER.info("It seems this scan is already running, cancelling previous execution.");
-      future.cancel(true);
+    try {
+      // create the associated scanner object, that handles the actual scanning
+      var scanner = scan.instantiateScanner();
+
+      // check, if it is somehow already running, and cancel it
+      var future = this.futures.get(scan.getId());
+      if (future != null) {
+        LOGGER.info("It seems this scan is already running, cancelling previous execution.");
+        future.cancel(true);
+      }
+
+      // increase thread pool size
+      int size =
+          Math.min(this.scheduler.getCorePoolSize() + 1, this.scheduler.getMaximumPoolSize());
+
+      this.scheduler.setCorePoolSize(size);
+      LOGGER.info("Adjusting thread pool size to {}", this.scheduler.getCorePoolSize());
+
+      LOGGER.info("Starting scan {}. Now waiting for next execution", scan.getId());
+
+      future =
+          scheduler.scheduleAtFixedRate(
+              () -> {
+                // set discovering flag to enable its indication in the discovery view
+                scan.setDiscovering(true);
+
+                // scan
+                var result = scanner.scan();
+
+                submit(scan, result);
+
+                // TODO: route this through pub/sub
+                /*var subscribers = this.subscriptions.get(scanner.getId());
+                for (Iterator<EventOutput> iterator = subscribers.iterator(); iterator.hasNext(); ) {
+                  var subscriber = iterator.next();
+                  var event =
+                      new OutboundEvent.Builder()
+                          .mediaType(MediaType.APPLICATION_JSON_TYPE)
+                          .name("discovery-complete")
+                          .data(DiscoveryResult.class, result)
+                          .build();
+
+                  try {
+                    if (!subscriber.isClosed()) {
+                      subscriber.write(event);
+                    }
+                    if (subscriber.isClosed()) {
+                      LOGGER.debug("Removing " + subscriber + " for type " + scanner.getId() + "...");
+                      iterator.remove();
+                    }
+
+                  } catch (IOException e) {
+                    LOGGER.error("Could not send event {} to subscriber", event.getName());
+                  }
+                }*/
+
+                scan.setLastResult(result);
+
+                LOGGER.info("Scan {} is now waiting for next execution.", scan.getId());
+                scan.setDiscovering(false);
+
+                // update database
+                PersistenceManager.getInstance().persist(scan);
+              },
+              0,
+              scan.getInterval(),
+              TimeUnit.SECONDS);
+
+      // store the future, so we can cancel it later
+      this.futures.put(scan.getId(), future);
+
+      // store the scanner, so we can access it later
+      this.scanners.put(scan.getId(), scanner);
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException e) {
+      LOGGER.error("Cannot instantiate scanner from {}: {}", scan.getId(), e.getMessage());
+
+      // disable it again
+      disableScan(scan);
     }
-
-    LOGGER.info("Starting scan {}. Now waiting for next execution", scan.getId());
-
-    // store the future, so we can cancel it later
-    future =
-        scheduler.scheduleAtFixedRate(
-            () -> {
-              // set discovering flag to enable its indication in the discovery view
-              scan.setDiscovering(true);
-
-              // scan
-              var result = scanner.scan();
-
-              submit(scan, result);
-
-              // TODO: route this through pub/sub
-              /*var subscribers = this.subscriptions.get(scanner.getId());
-              for (Iterator<EventOutput> iterator = subscribers.iterator(); iterator.hasNext(); ) {
-                var subscriber = iterator.next();
-                var event =
-                    new OutboundEvent.Builder()
-                        .mediaType(MediaType.APPLICATION_JSON_TYPE)
-                        .name("discovery-complete")
-                        .data(DiscoveryResult.class, result)
-                        .build();
-
-                try {
-                  if (!subscriber.isClosed()) {
-                    subscriber.write(event);
-                  }
-                  if (subscriber.isClosed()) {
-                    LOGGER.debug("Removing " + subscriber + " for type " + scanner.getId() + "...");
-                    iterator.remove();
-                  }
-
-                } catch (IOException e) {
-                  LOGGER.error("Could not send event {} to subscriber", event.getName());
-                }
-              }*/
-
-              scan.setLastResult(result);
-
-              LOGGER.info("Scan {} is now waiting for next execution.", scan.getId());
-              scan.setDiscovering(false);
-            },
-            0,
-            scan.getInterval(),
-            TimeUnit.SECONDS);
-
-    this.futures.put(scanner.getId(), future);
   }
 
   public int submit(Scan scan, DiscoveryResult result) {
@@ -210,6 +245,12 @@ public class DiscoveryService {
     future.cancel(true);
 
     LOGGER.info("Stopped scan {}", scan.getId());
+
+    // decrease thread pool size
+    int size = Math.max(this.scheduler.getCorePoolSize() - 1, 0);
+
+    this.scheduler.setCorePoolSize(size);
+    LOGGER.info("Adjusting thread pool size to {}", this.scheduler.getCorePoolSize());
   }
 
   public void subscribe(DiscoveryResultSubscriber subscriber) {
@@ -217,17 +258,23 @@ public class DiscoveryService {
   }
 
   public Scan getScan(String id) {
-    return this.scans.get(id);
+    return PersistenceManager.getInstance().getById(Scan.class, id);
   }
 
   public void enableScan(Scan scan) {
     scan.setEnabled(true);
+
+    // update database
+    PersistenceManager.getInstance().persist(scan);
 
     this.startScan(scan);
   }
 
   public void disableScan(Scan scan) {
     scan.setEnabled(false);
+
+    // update database
+    PersistenceManager.getInstance().persist(scan);
 
     this.stopScan(scan);
   }
@@ -238,12 +285,17 @@ public class DiscoveryService {
 
     // add to the subscription map for given asset type
 
-    // make sure a hashset exists
+    // make sure a hash set exists
     var set = this.subscriptions.putIfAbsent(assetType, new HashSet<>());
     Objects.requireNonNull(set).add(output);
 
     LOGGER.info("Subscribed an SSE client to asset type {}", assetType);
 
     return output;
+  }
+
+  /** Returns a list of currently running scanners. */
+  public Collection<Scanner> getScanners() {
+    return this.scanners.values();
   }
 }

--- a/clouditor-engine-core/src/main/java/io/clouditor/discovery/Scanner.java
+++ b/clouditor-engine-core/src/main/java/io/clouditor/discovery/Scanner.java
@@ -60,7 +60,7 @@ public abstract class Scanner<C, T> {
 
   protected ScannerPostProcessor<?, T> postProcessor;
 
-  protected final Supplier<C> supplier;
+  private final Supplier<C> supplier;
   private final Function<T, String> idGenerator;
   private final Function<T, String> nameGenerator;
 
@@ -174,5 +174,9 @@ public abstract class Scanner<C, T> {
 
   public boolean getInitialized() {
     return initialized;
+  }
+
+  public ScannerInfo getInfo() {
+    return this.getClass().getAnnotation(ScannerInfo.class);
   }
 }

--- a/clouditor-engine-core/src/test/java/io/clouditor/discovery/DiscoveryServiceTest.java
+++ b/clouditor-engine-core/src/test/java/io/clouditor/discovery/DiscoveryServiceTest.java
@@ -72,8 +72,6 @@ class DiscoveryServiceTest extends AbstractEngineUnitTest {
 
     var scan = scanService.getScan("fake");
 
-    assertTrue(scan.getScanner() instanceof FakeScanner);
-
     scanService.enableScan(scan);
 
     assertTrue(scan.isEnabled());

--- a/clouditor-engine-core/src/test/java/io/clouditor/discovery/DiscoveryServiceTest.java
+++ b/clouditor-engine-core/src/test/java/io/clouditor/discovery/DiscoveryServiceTest.java
@@ -57,7 +57,7 @@ class DiscoveryServiceTest extends AbstractEngineUnitTest {
 
     assertNotNull(scanService);
 
-    scanService.load();
+    scanService.init();
 
     var scans = scanService.getScans();
 


### PR DESCRIPTION
Instead of storing `Scan` objects in memory, all changes are now written to the persistance layer. When the `DiscoveryService` is initialized, enabled checks are automatically started. `Scanner` objects are now automatically created if the scan starts.