### PR TITLE
BSI C5:2020

### DIFF
--- a/clouditor-engine-aws/src/main/resources/rules/aws/cloudtrail/account-cloud-trail-active.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/cloudtrail/account-cloud-trail-active.md
@@ -10,5 +10,3 @@ Account has cloudTrailActive == true
 
 * AWS 2.1
 * BSI C5/OPS-10
-* BSI C5/OPS-11
-* BSI C5/OPS-13

--- a/clouditor-engine-aws/src/main/resources/rules/aws/cloudtrail/account-cloud-trail-active.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/cloudtrail/account-cloud-trail-active.md
@@ -9,6 +9,6 @@ Account has cloudTrailActive == true
 ## Controls
 
 * AWS 2.1
-* BSI C5/SIM-05
-* BSI C5/RB-10
-* BSI C5/RB-11
+* BSI C5/OPS-10
+* BSI C5/OPS-11
+* BSI C5/OPS-13

--- a/clouditor-engine-aws/src/main/resources/rules/aws/cloudtrail/trail-encrypted.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/cloudtrail/trail-encrypted.md
@@ -13,4 +13,4 @@ The trail with ARN {} is not encrypted (it has no KMS Key ID set)
 ## Controls
 
 * AWS 2.7
-* BSI C5/RB-13
+* BSI C5/OPS-14

--- a/clouditor-engine-aws/src/main/resources/rules/aws/dynamodb/table-encrypted.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/dynamodb/table-encrypted.md
@@ -8,4 +8,4 @@ Table has sseDescription.statusAsString == "ENABLED"
 
 ## Controls
 
-* BSI C5/KRY-03
+* BSI C5/CRY-03

--- a/clouditor-engine-aws/src/main/resources/rules/aws/ec2/volume-encryption.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/ec2/volume-encryption.md
@@ -8,4 +8,4 @@ Volume has encrypted == true
 
 ## Controls
 
-* BSI C5/KRY-03
+* BSI C5/CRY-03

--- a/clouditor-engine-aws/src/main/resources/rules/aws/iam/access-key-rotation.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/iam/access-key-rotation.md
@@ -10,4 +10,4 @@ User has createDate younger 90 days in all accessKeys
 
 * IAM-02
 * AWS 1.4
-* BSI C5/KRY-04
+* BSI C5/CRY-04

--- a/clouditor-engine-aws/src/main/resources/rules/aws/iam/inactive-access-keys.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/iam/inactive-access-keys.md
@@ -8,5 +8,5 @@ User has statusAsString != "Inactive" in all accessKeys
 
 ## Controls
 
-* BSI C5/KRY-04
+* BSI C5/CRY-04
 * BSI C5/IDM-01

--- a/clouditor-engine-aws/src/main/resources/rules/aws/iam/mfa.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/iam/mfa.md
@@ -10,4 +10,4 @@ User has not empty mfaDevices
 
 * IAM-09
 * AWS 1.2
-* BSI C5/IDM-08
+* BSI C5/IDM-09

--- a/clouditor-engine-aws/src/main/resources/rules/aws/kinesis/stream-encryption.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/kinesis/stream-encryption.md
@@ -8,4 +8,4 @@ StreamDescription has encryptionTypeAsString == "KMS"
 
 # Controls
 
-* BSI C5/KRY-03
+* BSI C5/CRY-03

--- a/clouditor-engine-aws/src/main/resources/rules/aws/kms/key-origin-external.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/kms/key-origin-external.md
@@ -6,4 +6,7 @@ Checks if the KMS keys have the correct origin (default: 'external'). Master key
 KeyMetadata has originAsString == "EXTERNAL"
 ```
 
+## Controls
+* BSI C5/CRY-04
+
 [comment]: # TODO merge together all key origin checks and parametrize the rule

--- a/clouditor-engine-aws/src/main/resources/rules/aws/kms/key-rotation.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/kms/key-rotation.md
@@ -8,7 +8,7 @@ KeyMetadata has keyRotationEnabled == true
 
 ## Controls:
 
-* BSI C5/KRY-04
+* BSI C5/CRY-04
 
 [comment]: # TODO: actually filter out external and master keys, since they cannot be rotated
 [comment]: # filter: 'KeyMetadata has originAsType == "AWS_KMS"'

--- a/clouditor-engine-aws/src/main/resources/rules/aws/lambda/function-env-encryption.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/lambda/function-env-encryption.md
@@ -8,4 +8,4 @@ FunctionDeclaration has not empty kmsKeyArn
 
 # Controls
 
-* BSI C5/KRY-03
+* BSI C5/CRY-03

--- a/clouditor-engine-aws/src/main/resources/rules/aws/rds/db-encryption.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/rds/db-encryption.md
@@ -8,4 +8,4 @@ Database has storageEncrypted == true
 
 ## Controls
 
-* BSI C5/IDM-01
+* BSI C5/CRY-03

--- a/clouditor-engine-aws/src/main/resources/rules/aws/s3/bucket-default-encryption.md
+++ b/clouditor-engine-aws/src/main/resources/rules/aws/s3/bucket-default-encryption.md
@@ -8,4 +8,4 @@ Bucket has (not empty applyServerSideEncryptionByDefault.sseAlgorithmAsString) i
 
 ## Controls
 
-* BSI C5/KRY-03
+* BSI C5/CRY-03

--- a/clouditor-engine-azure/src/main/resources/rules/azure/compute/vm-data-encryption.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/compute/vm-data-encryption.md
@@ -13,3 +13,4 @@ VirtualMachine has dataDiskEncryption == "Encrypted"
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 7.3
+* BSI C5/CRY-03

--- a/clouditor-engine-azure/src/main/resources/rules/azure/compute/vm-monitoring-extension.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/compute/vm-monitoring-extension.md
@@ -10,3 +10,4 @@ VirtualMachine has name == "MicrosoftMonitoringAgent" in extensions
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 7.1
+* BSI C5/OPS-10

--- a/clouditor-engine-azure/src/main/resources/rules/azure/compute/vm-os-encryption.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/compute/vm-os-encryption.md
@@ -9,3 +9,4 @@ VirtualMachine has osDiskEncryption == "Encrypted"
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 7.2
+* BSI C5/CRY-03

--- a/clouditor-engine-azure/src/main/resources/rules/azure/keyvault/key-expiry.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/keyvault/key-expiry.md
@@ -9,3 +9,4 @@ KeyVault has attributes.exp before 365 days in all keys
 ## Controls
   
 * CIS Microsoft Azure Foundations Benchmark/Azure 8.1
+* BSI C5/CRY-04

--- a/clouditor-engine-azure/src/main/resources/rules/azure/keyvault/secret-expiry.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/keyvault/secret-expiry.md
@@ -9,3 +9,4 @@ KeyVault has attributes.exp before 365 days in all secrets
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 8.2
+* BSI C5/CRY-04

--- a/clouditor-engine-azure/src/main/resources/rules/azure/keyvault/vault-logging.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/keyvault/vault-logging.md
@@ -10,3 +10,4 @@ KeyVault has retentionPolicy.days >= 180 in any logs
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 5.13
+* BSI C5/OPS-10

--- a/clouditor-engine-azure/src/main/resources/rules/azure/logging/log-profile-enabled.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/logging/log-profile-enabled.md
@@ -10,3 +10,4 @@ Subscription has retentionPolicy.days >= 365 in all logProfiles
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 5.2
+* BSI C5/OPS-10

--- a/clouditor-engine-azure/src/main/resources/rules/azure/network/nsg-flow-log-enabled.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/network/nsg-flow-log-enabled.md
@@ -11,3 +11,5 @@ NetworkSecurityGroup has flowLogSettings.retentionPolicy.days >= 90
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 6.4
+* BSI C5/OPS-10
+* BSI C5/OPS-13

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-database-auditing.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-database-auditing.md
@@ -11,5 +11,6 @@ SQLDatabase has auditingPolicy.retentionDays > 90
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.2.1
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.2.7
+* BSI C5/OPS-10
 
 [comment]: # TODO: retentionDays == 0 is also valid, since this means forever

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-database-encryption.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-database-encryption.md
@@ -9,3 +9,4 @@ SQLDatabase has transparentDataEncryption.status == "Enabled"
 # Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.2.6
+* BSI C5/CRY-03

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-emails.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-emails.md
@@ -11,3 +11,4 @@ SQLServer has securityAlertPolicy.emailAccountAdmins == true
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.4
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.5
+* BSI C5/OPS-13

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-enabled.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-enabled.md
@@ -10,3 +10,5 @@ SQLServer has not empty securityAlertPolicy.storageEndpoint
 ## Cntrols
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.2
+* BSI C5/OPS-10
+* BSI C5/OPS-13

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-no-disabled-alerts.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-no-disabled-alerts.md
@@ -9,3 +9,5 @@ SQLServer has empty securityAlertPolicy.disabledAlerts
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.3
+* BSI C5/OPS-10
+* BSI C5/OPS-13

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-storage.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-advanced-data-security-storage.md
@@ -10,5 +10,6 @@ SQLServer has securityAlertPolicy.retentionDays >= 90
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.7
+* BSI C5/OPS-14
 
 [comment]: # TODO: retentionDays == 0 is also ok

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-auditing.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-auditing.md
@@ -11,5 +11,6 @@ SQLServer has auditingPolicy.retentionDays >= 90
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.1
 * CIS Microsoft Azure Foundations Benchmark/Azure 4.1.6
+* BSI C5/OPS-10
 
 [comment]: # # TODO: retentionDays == 0 is also valid, since this means forever

--- a/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-uyok.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/sql/sql-server-uyok.md
@@ -5,3 +5,6 @@ Checks, whether certain Azure SQL servers have key vault keys stored in their en
 ```ccl
 SQLServer has encryptionProtectors.serverKeyType == "AzureKeyVault"
 ```
+
+## Controls
+* BSI C5/CRY-04

--- a/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-access-key.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-access-key.md
@@ -9,3 +9,4 @@ StorageAccount has keyRegenerated == true
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 3.3
+* BSI C5/CRY-04

--- a/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-blob-encrypted.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-blob-encrypted.md
@@ -9,3 +9,4 @@ StorageAccount has encryptionStatuses.Blob.enabled == true
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 3.2
+* BSI C5/CRY-03

--- a/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-enforce-secure-transfer.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-enforce-secure-transfer.md
@@ -9,3 +9,4 @@ StorageAccount has properties.supportsHttpsTrafficOnly == true
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 3.1
+* BSI C5/CRY-02

--- a/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-file-encrypted.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/storage/storage-account-file-encrypted.md
@@ -9,3 +9,4 @@ StorageAccount has File == true in encryptionStatuses
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 3.6
+* BSI C5/CRY-03

--- a/clouditor-engine-azure/src/main/resources/rules/azure/subscription/subscription-network-watchers.md
+++ b/clouditor-engine-azure/src/main/resources/rules/azure/subscription/subscription-network-watchers.md
@@ -9,3 +9,5 @@ Subscription has enabled == true in all watchers
 ## Controls
 
 * CIS Microsoft Azure Foundations Benchmark/Azure 6.5
+* BSI C5/OPS-10
+* BSI C5/OPS-13

--- a/clouditor-engine-core/src/main/java/io/clouditor/assurance/C5Importer.java
+++ b/clouditor-engine-core/src/main/java/io/clouditor/assurance/C5Importer.java
@@ -37,7 +37,7 @@ public class C5Importer extends CertificationImporter {
   @Override
   public Certification load() {
     var url =
-        "https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/CloudComputing/ComplianceControlsCatalogue/2016/ComplianceControlsCatalogue_tables_editable.xlsx?__blob=publicationFile&v=8";
+        "https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/CloudComputing/ComplianceControlsCatalogue/2020/C5_2020_editable.xlsx?__blob=publicationFile&v=1";
 
     LOGGER.info("Fetching BSI C5 from {}...", url);
 


### PR DESCRIPTION
This PR updates the BSI C5 catalogue to the 2020 version:
- updates the link to the up-to-date xls
- updates the checks' references according to the changelog provided by BSI: https://www.bsi.bund.de/EN/Topics/CloudComputing/Compliance_Criteria_Catalogue/C5_NewRelease/C5_Changes_node.html
- closes #70 