### PR TITLE
Trying deep source again

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_root = "clouditor.io/clouditor"


### PR DESCRIPTION
It may have been an issue with our vanity URL for go modules https://clouditor.io/clouditor and a misguided TLS certificate from GitHub.