### PR TITLE
Switched to golang-jwt's fork of github.com/dgrijalva/jwt-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,3 +26,5 @@ require (
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/gorm v1.21.10
 )
+
+replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v0.0.0-20210527125010-9e96e9651418

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v0.0.0-20210527125010-9e96e9651418 h1:enLluoZtnoPIP9kdHOySLQsLr341Lmhx2XG1vKbEp8U=
+github.com/golang-jwt/jwt v0.0.0-20210527125010-9e96e9651418/go.mod h1:+p//S9doV/bQgQAIccnJTnjzzXfMMFPys/33QTsH8ks=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
https://github.com/dgrijalva/jwt-go is no longer maintained. A community clone is available, which will aim to fix the relevant flaws in the project. Until their new module path is available, a simple replace is done.