### PR TITLE
Added a token to codecov-action@v1.5.0 step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           files: coverage.cov
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }} # not needed, but seems to be more reliable
       - name: "Upload Artifact"
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
It is not needed for a public repository, but it seems to be more reliable