### PR TITLE
Properly printing error message in `StartDiscovery`

### DIFF
--- a/service/discovery/discovery.go
+++ b/service/discovery/discovery.go
@@ -154,7 +154,17 @@ func (s Service) Shutdown() {
 }
 
 func (s Service) StartDiscovery(discoverer discovery.Discoverer) {
-	list, _ := discoverer.List()
+	var (
+		err  error
+		list []voc.IsResource
+	)
+
+	list, err = discoverer.List()
+
+	if err != nil {
+		log.Errorf("Could not retrieve resources from discoverer '%s': %v", discoverer.Name(), err)
+		return
+	}
 
 	for _, resource := range list {
 		s.resources[string(resource.GetID())] = resource


### PR DESCRIPTION
Fixes #279
