### PR TITLE
Code cleanup and formatting

### DIFF
--- a/api/assessment/metric_test.go
+++ b/api/assessment/metric_test.go
@@ -2,8 +2,9 @@ package assessment
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMetric_Validate(t *testing.T) {
@@ -67,7 +68,7 @@ func TestMetric_Validate(t *testing.T) {
 				WithMetricRequiresId(),
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.Nil(t, err)
+				return assert.NoError(t, err)
 			},
 		},
 	}

--- a/api/evidence/evidence_test.go
+++ b/api/evidence/evidence_test.go
@@ -154,7 +154,7 @@ func Test_ValidateEvidence(t *testing.T) {
 func toStruct(r voc.IsCloudResource, t *testing.T) (s *structpb.Value) {
 	s, err := voc.ToStruct(r)
 	if err != nil {
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 	}
 
 	return

--- a/cli/commands/assessmentresult/assessment_result_test.go
+++ b/cli/commands/assessmentresult/assessment_result_test.go
@@ -144,12 +144,12 @@ func TestNewListResultsCommand(t *testing.T) {
 
 	cmd := NewListAssessmentResultsCommand()
 	err := cmd.RunE(nil, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var response = &assessment.ListAssessmentResultsResponse{}
 	err = protojson.Unmarshal(b.Bytes(), response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.Results)
 }

--- a/cli/commands/cloud/cloud_test.go
+++ b/cli/commands/cloud/cloud_test.go
@@ -121,11 +121,11 @@ func TestRegisterCloudServiceCommand(t *testing.T) {
 	cmd := NewRegisterCloudServiceCommand()
 	err = cmd.RunE(nil, []string{"not_default"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = protojson.Unmarshal(b.Bytes(), &response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "not_default", response.Name)
 }
 
@@ -139,11 +139,11 @@ func TestListCloudServicesCommand(t *testing.T) {
 	cmd := NewListCloudServicesCommand()
 	err = cmd.RunE(nil, []string{})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = protojson.Unmarshal(b.Bytes(), &response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, response.Services)
 }
 
@@ -157,11 +157,11 @@ func TestGetCloudServiceCommand(t *testing.T) {
 	cmd := NewGetCloudServiceComand()
 	err = cmd.RunE(nil, []string{target.Id})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = protojson.Unmarshal(b.Bytes(), &response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, target.Id, response.Id)
 }
 
@@ -175,16 +175,16 @@ func TestRemoveCloudServicesCommand(t *testing.T) {
 	cmd := NewRemoveCloudServiceComand()
 	err = cmd.RunE(nil, []string{target.Id})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = protojson.Unmarshal(b.Bytes(), &response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Re-create default service
 	_, err = s.CreateDefaultTargetCloudService()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestUpdateCloudServiceCommand(t *testing.T) {
@@ -200,11 +200,11 @@ func TestUpdateCloudServiceCommand(t *testing.T) {
 	cmd := NewUpdateCloudServiceCommand()
 	err = cmd.RunE(nil, []string{})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = protojson.Unmarshal(b.Bytes(), &response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, target.Id, response.Id)
 	assert.Equal(t, "not_default", response.Name)
 }
@@ -222,10 +222,10 @@ func TestGetMetricConfiguration(t *testing.T) {
 	target, err = s.RegisterCloudService(context.TODO(), &orchestrator.RegisterCloudServiceRequest{Service: &orchestrator.CloudService{Name: "myservice"}})
 
 	assert.NotNil(t, target)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	cmd := NewGetMetricConfigurationCommand()
 	err = cmd.RunE(nil, []string{target.Id, "TransportEncryptionEnabled"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/cli/commands/evidence/evidence_test.go
+++ b/cli/commands/evidence/evidence_test.go
@@ -137,12 +137,12 @@ func TestNewListResultsCommand(t *testing.T) {
 
 	cmd := NewListEvidencesCommand()
 	err := cmd.RunE(nil, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var response = &evidence.ListEvidencesResponse{}
 	err = protojson.Unmarshal(b.Bytes(), response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.Evidences)
 }

--- a/cli/commands/login/login_test.go
+++ b/cli/commands/login/login_test.go
@@ -70,7 +70,7 @@ func TestLogin(t *testing.T) {
 	defer server.Stop()
 
 	dir, err = ioutil.TempDir(os.TempDir(), ".clouditor")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, dir)
 
 	viper.Set("username", "clouditor")
@@ -79,5 +79,5 @@ func TestLogin(t *testing.T) {
 
 	cmd := NewLoginCommand()
 	err = cmd.RunE(nil, []string{fmt.Sprintf("localhost:%d", sock.Addr().(*net.TCPAddr).Port)})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/cli/commands/metric/metric_test.go
+++ b/cli/commands/metric/metric_test.go
@@ -106,13 +106,13 @@ func TestListMetrics(t *testing.T) {
 	cmd := NewListMetricsCommand()
 	err = cmd.RunE(nil, []string{})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var response *orchestrator.ListMetricsResponse = &orchestrator.ListMetricsResponse{}
 
 	err = protojson.Unmarshal(b.Bytes(), response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.Metrics)
 }
@@ -126,5 +126,5 @@ func TestGetMetric(t *testing.T) {
 	cmd := NewGetMetricCommand()
 	err = cmd.RunE(nil, []string{"TransportEncryptionEnabled"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/cli/commands/resource/resource_test.go
+++ b/cli/commands/resource/resource_test.go
@@ -126,12 +126,12 @@ func TestNewListCommand(t *testing.T) {
 
 	cmd := NewListResourcesCommand()
 	err = cmd.RunE(nil, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var response = &discovery.QueryResponse{}
 	err = protojson.Unmarshal(b.Bytes(), response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.Results.Values)
 

--- a/cli/commands/service/discovery/discovery_test.go
+++ b/cli/commands/service/discovery/discovery_test.go
@@ -125,7 +125,7 @@ func TestNewStartDiscoveryCommand(t *testing.T) {
 
 	cmd := NewStartDiscoveryCommand()
 	err = cmd.RunE(nil, []string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	var response = &discovery.StartDiscoveryResponse{}
 	assert.NotNil(t, response)
@@ -141,12 +141,12 @@ func TestNewQueryDiscoveryCommand(t *testing.T) {
 
 	cmd := NewQueryDiscoveryCommand()
 	err = cmd.RunE(nil, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var response = &discovery.QueryResponse{}
 	err = protojson.Unmarshal(b.Bytes(), response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.Results.Values)
 }

--- a/cli/commands/service/orchestrator/orchestrator_test.go
+++ b/cli/commands/service/orchestrator/orchestrator_test.go
@@ -144,12 +144,12 @@ func TestNewListResultsCommand(t *testing.T) {
 
 	cmd := NewListAssessmentResultsCommand()
 	err := cmd.RunE(nil, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var response = &assessment.ListAssessmentResultsResponse{}
 	err = protojson.Unmarshal(b.Bytes(), response)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.Results)
 }

--- a/cli/commands/tool/tool_test.go
+++ b/cli/commands/tool/tool_test.go
@@ -101,7 +101,7 @@ func TestListTool(t *testing.T) {
 	err = cmd.RunE(nil, []string{})
 
 	// unsupported for now
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "method ListAssessmentTools not implemented", err.Error())
 }
 
@@ -112,7 +112,7 @@ func TestShowTool(t *testing.T) {
 	err = cmd.RunE(nil, []string{"1"})
 
 	// unsupported for now
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "method GetAssessmentTool not implemented", err.Error())
 }
 
@@ -123,7 +123,7 @@ func TestUpdateTool(t *testing.T) {
 	err = cmd.RunE(nil, []string{"1"})
 
 	// unsupported for now
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "method UpdateAssessmentTool not implemented", err.Error())
 }
 
@@ -134,7 +134,7 @@ func TestRegisterTool(t *testing.T) {
 	err = cmd.RunE(nil, []string{})
 
 	// unsupported for now
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "method RegisterAssessmentTool not implemented", err.Error())
 }
 
@@ -145,6 +145,6 @@ func TestDeregisterTool(t *testing.T) {
 	err = cmd.RunE(nil, []string{"1"})
 
 	// unsupported for now
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "method DeregisterAssessmentTool not implemented")
 }

--- a/cli/session_test.go
+++ b/cli/session_test.go
@@ -75,7 +75,7 @@ func TestSession(t *testing.T) {
 	defer server.Stop()
 
 	dir, err = ioutil.TempDir(os.TempDir(), ".clouditor")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, dir)
 
 	viper.Set("session-directory", dir)
@@ -86,7 +86,7 @@ func TestSession(t *testing.T) {
 	}
 	defer session.Close()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, session)
 	assert.Equal(t, dir, session.Folder)
 
@@ -97,7 +97,7 @@ func TestSession(t *testing.T) {
 	// login with real user
 	response, err = client.Login(context.Background(), &auth.LoginRequest{Username: "clouditor", Password: "clouditor"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.NotEmpty(t, response.AccessToken)
 
@@ -106,10 +106,10 @@ func TestSession(t *testing.T) {
 
 	err = session.Save()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	session, err = ContinueSession()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, session)
 
 	client = auth.NewAuthenticationClient(session)
@@ -118,7 +118,7 @@ func TestSession(t *testing.T) {
 	// TODO(oxisto): Should be moved to a service/auth test. here we should only test the session mechanism
 	response, err = client.Login(context.Background(), &auth.LoginRequest{Username: "some-other-user", Password: "password"})
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	s, ok := status.FromError(err)
 
@@ -191,5 +191,5 @@ func TestSession_HandleResponse(t *testing.T) {
 // Test will fail due to no user input
 func TestPromptForLogin(t *testing.T) {
 	_, err := PromptForLogin()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -251,7 +251,7 @@ func TestRunEvidence(t *testing.T) {
 	}
 	for _, tt := range tests {
 		resource, err := voc.ToStruct(tt.fields.resource)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		t.Run(tt.name, func(t *testing.T) {
 			results, err := RunEvidence(&evidence.Evidence{
 				Id:       tt.fields.evidenceID,

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -117,7 +117,7 @@ func TestREST(t *testing.T) {
 
 	port, err := GetServerPort()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEqual(t, 0, port)
 
 	type args struct {
@@ -224,7 +224,7 @@ func TestREST(t *testing.T) {
 			}
 
 			req, err := http.NewRequest(method, fmt.Sprintf("http://localhost:%d/%s", port, tt.args.url), nil)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, req)
 
 			req.Header.Add("Origin", tt.args.origin)
@@ -237,7 +237,7 @@ func TestREST(t *testing.T) {
 
 			assert.Equal(t, tt.statusCode, resp.StatusCode)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 
 			for key, value := range tt.headers {

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -320,7 +320,7 @@ func TestAssessEvidences(t *testing.T) {
 func TestAssessmentResultHooks(t *testing.T) {
 	var (
 		hookCallCounter = 0
-		wg sync.WaitGroup
+		wg              sync.WaitGroup
 	)
 
 	wg.Add(12)
@@ -419,10 +419,10 @@ func TestListAssessmentResults(t *testing.T) {
 			Timestamp: timestamppb.Now(),
 			Resource:  toStruct(voc.VirtualMachine{Compute: &voc.Compute{CloudResource: &voc.CloudResource{ID: "my-resource-id", Type: []string{"VirtualMachine"}}}}, t),
 		}})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	var results *assessment.ListAssessmentResultsResponse
 	results, err = s.ListAssessmentResults(context.TODO(), &assessment.ListAssessmentResultsRequest{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, results)
 }
 
@@ -430,7 +430,7 @@ func TestListAssessmentResults(t *testing.T) {
 func toStruct(r voc.IsCloudResource, t *testing.T) (s *structpb.Value) {
 	s, err := voc.ToStruct(r)
 	if err != nil {
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 	}
 
 	return

--- a/service/discovery/aws/aws_test.go
+++ b/service/discovery/aws/aws_test.go
@@ -30,12 +30,13 @@ package aws
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const mockRegion = "mockRegion"
@@ -63,7 +64,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	client, err := NewClient()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, mockRegion, client.cfg.Region)
 
 	// Case 2: Get error while loading credentials
@@ -74,7 +75,7 @@ func TestNewClient(t *testing.T) {
 		return
 	}
 	client, err = NewClient()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, client)
 
 	// Case 3: Get error while calling GetCallerIdentity
@@ -90,14 +91,14 @@ func TestNewClient(t *testing.T) {
 		return
 	}
 	client, err = NewClient()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, client)
 
 }
 
 type mockSTSClient struct{}
 
-func (m mockSTSClient) GetCallerIdentity(_ context.Context,
+func (mockSTSClient) GetCallerIdentity(_ context.Context,
 	_ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
 	return &sts.GetCallerIdentityOutput{
 		Account: aws.String("12345"),
@@ -106,7 +107,7 @@ func (m mockSTSClient) GetCallerIdentity(_ context.Context,
 
 type mockSTSClientWithAPIError struct{}
 
-func (m mockSTSClientWithAPIError) GetCallerIdentity(_ context.Context,
+func (mockSTSClientWithAPIError) GetCallerIdentity(_ context.Context,
 	_ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
 	return nil, &smithy.OperationError{
 		ServiceID:     "STS",

--- a/service/discovery/aws/compute_test.go
+++ b/service/discovery/aws/compute_test.go
@@ -28,9 +28,13 @@
 package aws
 
 import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
 	"clouditor.io/clouditor/api/discovery"
 	"clouditor.io/clouditor/voc"
-	"context"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -39,9 +43,6 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/stretchr/testify/assert"
-	"reflect"
-	"testing"
-	"time"
 )
 
 const (
@@ -205,14 +206,14 @@ func TestComputeDiscovery_List(t *testing.T) {
 		},
 	}
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, list)
 
 	d = computeDiscovery{
 		virtualMachineAPI: mockEC2APIWithErrors{},
 	}
 	_, err = d.List()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	d = computeDiscovery{
 		virtualMachineAPI: mockEC2API{},
@@ -226,7 +227,7 @@ func TestComputeDiscovery_List(t *testing.T) {
 		},
 	}
 	_, err = d.List()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestComputeDiscovery_discoverVirtualMachines(t *testing.T) {
@@ -241,7 +242,7 @@ func TestComputeDiscovery_discoverVirtualMachines(t *testing.T) {
 		},
 	}
 	machines, err := d.discoverVirtualMachines()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	testMachine := machines[0]
 	assert.Equal(t, mockVM1, testMachine.Name)
 	assert.Equal(t, voc.ResourceID("arn:aws:ec2:eu-central-1:MockAccountID1234:instance/mockVM1ID"), testMachine.ID)
@@ -255,7 +256,7 @@ func TestComputeDiscovery_discoverVirtualMachines(t *testing.T) {
 		virtualMachineAPI: mockEC2APIWithErrors{},
 	}
 	_, err = d.discoverVirtualMachines()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 }
 
@@ -392,7 +393,7 @@ func TestComputeDiscovery_discoverFunctions(t *testing.T) {
 		awsConfig:   mockClient,
 	}
 	functions, err := d.discoverFunctions()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Less(t, 50, len(functions))
 
 }

--- a/service/discovery/aws/storage_test.go
+++ b/service/discovery/aws/storage_test.go
@@ -296,7 +296,7 @@ func TestAwsS3Discovery_getBuckets(t *testing.T) {
 		},
 	}
 	buckets, err := d.getBuckets()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	log.Print("Testing number of buckets")
 	// We fetch buckets currently only of users region
@@ -329,7 +329,7 @@ func TestAwsS3Discovery_getBuckets(t *testing.T) {
 	}
 
 	_, err = d.getBuckets()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 // TestGetEncryptionAtRest tests the getEncryptionAtRest method
@@ -355,7 +355,7 @@ func TestAwsS3Discovery_getEncryptionAtRest(t *testing.T) {
 
 	// First case: SSE-S3 encryption
 	encryptionAtRest, err = d.getEncryptionAtRest(bucket{name: mockBucket1})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	managedEncryption, ok = encryptionAtRest.(voc.ManagedKeyEncryption)
 	assert.True(t, ok)
 	assert.True(t, managedEncryption.Enabled)
@@ -365,14 +365,14 @@ func TestAwsS3Discovery_getEncryptionAtRest(t *testing.T) {
 	encryptionAtRest, err = d.getEncryptionAtRest(bucket{name: mockBucket2, region: mockBucket2Region})
 	customerEncryption, ok = encryptionAtRest.(voc.CustomerKeyEncryption)
 	assert.True(t, ok)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, customerEncryption.Enabled)
 	assert.Equal(t, "", customerEncryption.Algorithm)
 	assert.Equal(t, "arn:aws:kms:"+mockBucket2Region+":"+mockAccountID+":key/"+mockBucket2KeyId, customerEncryption.KeyUrl)
 
 	// Third case: No encryption
 	encryptionAtRest, err = d.getEncryptionAtRest(bucket{name: "mockbucket3"})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, encryptionAtRest.GetAtRestEncryption().Enabled)
 
 	// 4th case: Connection error
@@ -381,7 +381,7 @@ func TestAwsS3Discovery_getEncryptionAtRest(t *testing.T) {
 		isDiscovering: false,
 	}
 	_, err = d.getEncryptionAtRest(bucket{name: "mockbucket4"})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 // TestGetTransportEncryption tests the getTransportEncryption method
@@ -392,7 +392,7 @@ func TestAwsS3Discovery_getTransportEncryption(t *testing.T) {
 		isDiscovering: false,
 	}
 	_, err := d.getTransportEncryption("")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	d = awsS3Discovery{
 		storageAPI:    mockS3APINew{},
@@ -401,26 +401,26 @@ func TestAwsS3Discovery_getTransportEncryption(t *testing.T) {
 
 	// Case 2: Enforced
 	encryptionAtTransit, err := d.getTransportEncryption(mockBucket1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, encryptionAtTransit.Enabled)
 	assert.Equal(t, "TLS1.2", encryptionAtTransit.TlsVersion)
 	assert.True(t, encryptionAtTransit.Enforced)
 
 	// Case 3: JSON failure
 	encryptionAtTransit, err = d.getTransportEncryption(mockBucket2)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, encryptionAtTransit)
 
 	// Case 4: Not enforced
 	encryptionAtTransit, err = d.getTransportEncryption(mockBucket3)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, encryptionAtTransit.Enabled)
 	assert.Equal(t, "TLS1.2", encryptionAtTransit.TlsVersion)
 	assert.False(t, encryptionAtTransit.Enforced)
 
 	// Case 5: No bucket policy == not enforced
 	encryptionAtTransit, err = d.getTransportEncryption("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, encryptionAtTransit.Enabled)
 	assert.Equal(t, "TLS1.2", encryptionAtTransit.TlsVersion)
 	assert.False(t, encryptionAtTransit.Enforced)
@@ -434,16 +434,16 @@ func TestAwsS3Discovery_getRegion(t *testing.T) {
 		isDiscovering: false,
 	}
 	actualRegion, err := d.getRegion(mockBucket1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, mockBucket1Region, actualRegion)
 
 	actualRegion, err = d.getRegion(mockBucket2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, mockBucket2Region, actualRegion)
 
 	// Error case
 	_, err = d.getRegion("mockbucketNotAvailable")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 }
 

--- a/service/discovery/azure/arm_template_test.go
+++ b/service/discovery/azure/arm_template_test.go
@@ -28,9 +28,10 @@ package azure
 import (
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"net/http"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"clouditor.io/clouditor/voc"
 	"github.com/jinzhu/copier"
@@ -309,7 +310,7 @@ func TestAzureARMTemplateAuthorizer(t *testing.T) {
 	d := NewAzureARMTemplateDiscovery()
 	list, err := d.List()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, list)
 	assert.Equal(t, "could not authorize Azure account: no authorized was available", err.Error())
 }
@@ -322,7 +323,7 @@ func TestARMTemplateDiscovery(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 	assert.Equal(t, 7, len(list))
 	assert.NotEmpty(t, d.Name())
@@ -336,7 +337,7 @@ func TestObjectStorageProperties(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	objectStorage, ok := list[2].(*voc.ObjectStorage)
@@ -375,7 +376,7 @@ func TestFileStorageProperties(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	fileStorage, ok := list[3].(*voc.FileStorage)
@@ -404,7 +405,7 @@ func TestVmProperties(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	resourceVM, ok := list[0].(*voc.VirtualMachine)
@@ -426,7 +427,7 @@ func TestLoadBalancerProperties(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	resourceLoadBalancer, ok := list[6].(*voc.LoadBalancer)
@@ -452,21 +453,21 @@ func TestARMTemplateHandleObjectStorageMethodWhenInputIsInvalid(t *testing.T) {
 	// check for dependsOn type assertion error
 	armTemplateHandleObjectStorageResponse, err := dependsOnTypeAssertionResponse("Object", armTemplateResources)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "dependsOn type assertion failed", err.Error())
 	assert.Nil(t, armTemplateHandleObjectStorageResponse)
 
 	// check for storageAccountResourceFromARMTemplate() response error
 	armTemplateHandleObjectStorageResponse, err = storageAccountResourceFromTemplateResponse("Object", armTemplateResources)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot get storage account resource from Azure ARM template:")
 	assert.Nil(t, armTemplateHandleObjectStorageResponse)
 
 	// check for storageAccountAtRestEncryptionFromARMtemplate() response error
 	armTemplateHandleObjectStorageResponse, err = storageAccountAtRestEncryptionFromARMResponse("Object", armTemplateResources)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot get atRestEncryption for storage account resource from Azure ARM template")
 	assert.Nil(t, armTemplateHandleObjectStorageResponse)
 }
@@ -485,21 +486,21 @@ func TestARMTemplateHandleFileStorageMethodWhenInputIsInvalid(t *testing.T) {
 	// check for dependsOn type assertion error
 	armTemplateHandleFileStorageResponse, err := dependsOnTypeAssertionResponse("File", armTemplateResources)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "dependsOn type assertion failed", err.Error())
 	assert.Nil(t, armTemplateHandleFileStorageResponse)
 
 	// check for storageAccountResourceFromARMTemplate() response error
 	armTemplateHandleFileStorageResponse, err = storageAccountResourceFromTemplateResponse("File", armTemplateResources)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot get storage account resource from Azure ARM template:")
 	assert.Nil(t, armTemplateHandleFileStorageResponse)
 
 	// check for storageAccountAtRestEncryptionFromARMtemplate() response error
 	armTemplateHandleFileStorageResponse, err = storageAccountAtRestEncryptionFromARMResponse("File", armTemplateResources)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot get atRestEncryption for storage account resource from Azure ARM template")
 	assert.Nil(t, armTemplateHandleFileStorageResponse)
 }
@@ -617,7 +618,7 @@ func TestMethodGetDefaultResourceNameFromParameter(t *testing.T) {
 	delete(modifiedARMTemplate["template"].(map[string]interface{})["parameters"].(map[string]interface{})["storageAccounts_storage1_name"].(map[string]interface{}), "defaultValue")
 	getDefaultResourceNameFromParameterResponse, err = defaultResourceNameFromParameter(modifiedARMTemplate["template"].(map[string]interface{}), "[parameters('storageAccounts_storage1_name')]")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "storageAccounts_storage1_name", getDefaultResourceNameFromParameterResponse)
 }
 

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -27,12 +27,13 @@ package azure
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"clouditor.io/clouditor/voc"
 	"github.com/stretchr/testify/assert"
@@ -184,7 +185,7 @@ func TestAzureComputeAuthorizer(t *testing.T) {
 	d := NewAzureComputeDiscovery()
 	list, err := d.List()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, list)
 	assert.Equal(t, "could not authorize Azure account: no authorized was available", err.Error())
 }
@@ -197,7 +198,7 @@ func TestCompute(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 	assert.Equal(t, 3, len(list))
 	assert.NotEmpty(t, d.Name())
@@ -210,7 +211,7 @@ func TestVirtualMachine(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	virtualMachine, ok := list[0].(*voc.VirtualMachine)
 
@@ -240,7 +241,7 @@ func TestFunction(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 	assert.Equal(t, 3, len(list))
 
@@ -255,7 +256,7 @@ func TestComputeDiscoverFunctionWhenInputIsInvalid(t *testing.T) {
 
 	discoverFunctionResponse, err := d.discoverFunction()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not list functions")
 	assert.Nil(t, discoverFunctionResponse)
 }
@@ -265,7 +266,7 @@ func TestComputeDiscoverVirtualMachines(t *testing.T) {
 
 	discoverVirtualMachineResponse, err := d.discoverVirtualMachines()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not list virtual machines")
 	assert.Nil(t, discoverVirtualMachineResponse)
 }

--- a/service/discovery/azure/network_test.go
+++ b/service/discovery/azure/network_test.go
@@ -121,7 +121,7 @@ func TestAzureNetworkAuthorizer(t *testing.T) {
 	d := NewAzureNetworkDiscovery()
 	list, err := d.List()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, list)
 	assert.Equal(t, "could not authorize Azure account: no authorized was available", err.Error())
 }
@@ -134,7 +134,7 @@ func TestNetwork(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 	assert.Equal(t, 2, len(list))
 	assert.NotEmpty(t, d.Name())
@@ -159,14 +159,14 @@ func TestComputeDiscoverMethodsWhenInputIsInvalid(t *testing.T) {
 	// Test method discoverNetworkInterfaces
 	discoverNetworkInterfacesResponse, err := d.discoverNetworkInterfaces()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not list network interfaces")
 	assert.Nil(t, discoverNetworkInterfacesResponse)
 
 	// Test method discoverLoadBalancer
 	discoverLoadBalancerResponse, err := d.discoverLoadBalancer()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not list load balancer")
 	assert.Nil(t, discoverLoadBalancerResponse)
 

--- a/service/discovery/azure/storage_test.go
+++ b/service/discovery/azure/storage_test.go
@@ -26,15 +26,16 @@
 package azure
 
 import (
-	"clouditor.io/clouditor/voc"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-02-01/storage"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"net/http"
 	"testing"
+
+	"clouditor.io/clouditor/voc"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-02-01/storage"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -263,7 +264,7 @@ func TestAzureStorageAuthorizer(t *testing.T) {
 	d := NewAzureStorageDiscovery()
 	list, err := d.List()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, list)
 	assert.Equal(t, "could not authorize Azure account: no authorized was available", err.Error())
 }
@@ -276,7 +277,7 @@ func TestStorage(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 	assert.Equal(t, 8, len(list))
 	assert.NotEmpty(t, d.Name())
@@ -289,7 +290,7 @@ func TestListObjectStorage(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	var counter int
@@ -308,7 +309,7 @@ func TestObjectStorage(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	objectStorage, ok := list[0].(*voc.ObjectStorage)
@@ -350,7 +351,7 @@ func TestListFileStorage(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	var counter int
@@ -369,7 +370,7 @@ func TestFileStorage(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	fileStorage, ok := list[2].(*voc.FileStorage)
@@ -395,7 +396,7 @@ func TestListBlockStorage(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	var counter int
@@ -414,7 +415,7 @@ func TestBlockStorage(t *testing.T) {
 	)
 
 	list, err := d.List()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	blockStorage, ok := list[6].(*voc.BlockStorage)
@@ -444,7 +445,7 @@ func TestStorageHandleMethodsWhenInputIsInvalid(t *testing.T) {
 	mockedStorageAccountObject.Encryption.KeySource = ""
 
 	handleObjectStorageRespone, err := handleObjectStorage(&mockedStorageAccountObject, containerItem)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, handleObjectStorageRespone)
 
 	// Test method handleFileStorage
@@ -454,7 +455,7 @@ func TestStorageHandleMethodsWhenInputIsInvalid(t *testing.T) {
 	mockedStorageAccountObject.Encryption.KeySource = ""
 
 	handleFileStorageRespone, err := handleFileStorage(&mockedStorageAccountObject, fileShare)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, handleFileStorageRespone)
 
 	// Test method handleBlockStorage
@@ -467,7 +468,7 @@ func TestStorageHandleMethodsWhenInputIsInvalid(t *testing.T) {
 	disk.Encryption.Type = ""
 
 	handleBlockStorageResponse, err := d.handleBlockStorage(disk)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, handleBlockStorageResponse)
 }
 
@@ -485,7 +486,7 @@ func TestStorageMethodsWhenInputIsInvalid(t *testing.T) {
 
 	// Test method storageAtRestEncryption
 	atRestEncryption, err := storageAtRestEncryption(&mockedStorageAccountObject)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	managedKeyEncryption := voc.ManagedKeyEncryption{AtRestEncryption: &voc.AtRestEncryption{Algorithm: "AES256", Enabled: true}}
 	assert.Equal(t, managedKeyEncryption, atRestEncryption)
@@ -505,23 +506,23 @@ func TestStorageDiscoverMethodsWhenInputIsInvalid(t *testing.T) {
 	}
 	// Test method discoverStorageAccounts
 	discoverStorageAccountsResponse, err := d.discoverStorageAccounts()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not list storage accounts")
 	assert.Nil(t, discoverStorageAccountsResponse)
 
 	// Test method discoverObjectStorages
 	discoverObjectStoragesResponse, err := d.discoverObjectStorages(&mockedStorageAccountObject)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, discoverObjectStoragesResponse)
 
 	// Test method discoverFileStorages
 	discoverFileStoragesResponse, err := d.discoverFileStorages(&mockedStorageAccountObject)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, discoverFileStoragesResponse)
 
 	// Test method discoverBlockStorages
 	discoverBlockStoragesResponse, err := d.discoverBlockStorages()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, discoverBlockStoragesResponse)
 }
 

--- a/service/discovery/k8s/compute_test.go
+++ b/service/discovery/k8s/compute_test.go
@@ -49,7 +49,7 @@ func TestListPods(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	container, ok := list[0].(*voc.Container)

--- a/service/discovery/k8s/network_test.go
+++ b/service/discovery/k8s/network_test.go
@@ -90,7 +90,7 @@ func TestListIngresses(t *testing.T) {
 
 	list, err := d.List()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, list)
 
 	service, ok := list[0].(*voc.NetworkService)

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -27,14 +27,15 @@ package evidences
 
 import (
 	"context"
-	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
 	"reflect"
 	"runtime"
 	"sync"
 	"testing"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"clouditor.io/clouditor/api/evidence"
 	"clouditor.io/clouditor/voc"
@@ -192,14 +193,14 @@ func TestListEvidences(t *testing.T) {
 	}
 
 	resp, err := s.ListEvidences(context.TODO(), &evidence.ListEvidencesRequest{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(resp.Evidences))
 }
 
 func TestEvidenceHook(t *testing.T) {
 	var (
 		hookCallCounter = 0
-		wg sync.WaitGroup
+		wg              sync.WaitGroup
 	)
 	wg.Add(2)
 
@@ -365,7 +366,7 @@ func (mockStreamer) RecvMsg(_ interface{}) error {
 func toStruct(r voc.IsCloudResource, t *testing.T) (s *structpb.Value) {
 	s, err := voc.ToStruct(r)
 	if err != nil {
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 	}
 
 	return

--- a/service/orchestrator/metrics_test.go
+++ b/service/orchestrator/metrics_test.go
@@ -44,7 +44,7 @@ func TestLoadMetrics(t *testing.T) {
 
 	err = LoadMetrics("metrics.json")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestService_CreateMetric(t *testing.T) {
@@ -230,6 +230,6 @@ func TestService_ListMetrics(t *testing.T) {
 
 	response, err = service.ListMetrics(context.TODO(), &orchestrator.ListMetricsRequest{})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, response.Metrics)
 }

--- a/service/orchestrator/orchestrator_test.go
+++ b/service/orchestrator/orchestrator_test.go
@@ -27,17 +27,18 @@ package orchestrator
 
 import (
 	"context"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"os"
 	"reflect"
 	"runtime"
 	"sync"
 	"testing"
+
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"clouditor.io/clouditor/api/assessment"
 	"clouditor.io/clouditor/persistence"
@@ -75,7 +76,7 @@ func TestMain(m *testing.M) {
 func TestAssessmentResultHook(t *testing.T) {
 	var (
 		hookCallCounter = 0
-		wg sync.WaitGroup
+		wg              sync.WaitGroup
 	)
 	wg.Add(2)
 
@@ -174,7 +175,7 @@ func TestListMetricConfigurations(t *testing.T) {
 
 	response, err = service.ListMetricConfigurations(context.TODO(), &orchestrator.ListMetricConfigurationRequest{})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, response.Configurations)
 }
 


### PR DESCRIPTION
Should not change anything. Just run `go fmt ./...` and `go generate ./...` to cleanup. Furthermore, made error assertions in unit tests more consistent.