### PR TITLE
Tie-in of metric configuration with Rego evaluation

### DIFF
--- a/api/orchestrator/orchestrator.proto
+++ b/api/orchestrator/orchestrator.proto
@@ -193,7 +193,7 @@ service Orchestrator {
     };
   }
 
-  // Lists all a metric configurations (target value and operator) for a specific service and metric ID
+  // Lists all a metric configurations (target value and operator) for a specific service ID
   rpc ListMetricConfigurations(ListMetricConfigurationRequest)
       returns (ListMetricConfigurationResponse) {
     option (google.api.http) = {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.14.0
 	github.com/aws/smithy-go v1.10.0
+	github.com/fatih/camelcase v1.0.0
 	github.com/go-co-op/gocron v1.12.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/google/uuid v1.3.0
@@ -24,6 +25,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0
 	github.com/jinzhu/copier v0.3.4
 	github.com/logrusorgru/aurora/v3 v3.0.0
+	github.com/mitchellh/mapstructure v1.4.3
 	github.com/open-policy-agent/opa v0.37.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
@@ -102,7 +104,6 @@ require (
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/policies/bundles/AnomalyDetectionEnabled/metric.rego
+++ b/policies/bundles/AnomalyDetectionEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.anomaly_detection_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/AnomalyDetectionOutput/metric.rego
+++ b/policies/bundles/AnomalyDetectionOutput/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.anomaly_detection_output
+
+import data.clouditor.isIn
 
 default applicable = false
 

--- a/policies/bundles/AnonymousAuthentication/metric.rego
+++ b/policies/bundles/AnonymousAuthentication/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.anonymous_authentication
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/AtRestEncryptionAlgorithm/metric.rego
+++ b/policies/bundles/AtRestEncryptionAlgorithm/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.at_rest_encryption_algorithm
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/AtRestEncryptionEnabled/metric.rego
+++ b/policies/bundles/AtRestEncryptionEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.at_rest_encryption_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/AutomaticUpdatesEnabled/metric.rego
+++ b/policies/bundles/AutomaticUpdatesEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.automatic_updates_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/AutomaticUpdatesInterval/metric.rego
+++ b/policies/bundles/AutomaticUpdatesInterval/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.automatic_updates_interval
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/AutomaticUpdatesSecurityOnly/metric.rego
+++ b/policies/bundles/AutomaticUpdatesSecurityOnly/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.automatic_updates_security_only
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/BootLoggingEnabled/metric.rego
+++ b/policies/bundles/BootLoggingEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.boot_logging_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/BootLoggingOutput/metric.rego
+++ b/policies/bundles/BootLoggingOutput/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.boot_logging_output
+
+import data.clouditor.isIn
 
 default applicable = false
 

--- a/policies/bundles/BootLoggingRetention/metric.rego
+++ b/policies/bundles/BootLoggingRetention/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.boot_logging_retention
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/BroadAssignments/metric.rego
+++ b/policies/bundles/BroadAssignments/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.broad_assignments
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/CustomerKeyEncryption/metric.rego
+++ b/policies/bundles/CustomerKeyEncryption/metric.rego
@@ -1,4 +1,4 @@
-package clouditor
+package clouditor.metrics.customer_key_encryption
 
 default applicable = false
 

--- a/policies/bundles/L3FirewallEnabled/metric.rego
+++ b/policies/bundles/L3FirewallEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.l_3_firewall_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/L3FirewallRestrictedPorts/metric.rego
+++ b/policies/bundles/L3FirewallRestrictedPorts/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.l_3_firewall_restricted_ports
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/MalwareProtectionEnabled/metric.rego
+++ b/policies/bundles/MalwareProtectionEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.malware_protection_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/MalwareProtectionOutput/metric.rego
+++ b/policies/bundles/MalwareProtectionOutput/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.malware_protection_output
+
+import data.clouditor.isIn
 
 default applicable = false
 

--- a/policies/bundles/MixedDuties/metric.rego
+++ b/policies/bundles/MixedDuties/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.mixed_duties
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/MutualAuthentication/metric.rego
+++ b/policies/bundles/MutualAuthentication/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.mutual_authentication
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/OSLoggingEnabled/metric.rego
+++ b/policies/bundles/OSLoggingEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.os_logging_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/OSLoggingOutput/metric.rego
+++ b/policies/bundles/OSLoggingOutput/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.os_logging_output
+
+import data.clouditor.isIn
 
 default applicable = false
 

--- a/policies/bundles/OSLoggingRetention/metric.rego
+++ b/policies/bundles/OSLoggingRetention/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.os_logging_retention
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/RuntimeVersion/metric.rego
+++ b/policies/bundles/RuntimeVersion/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.runtime_version
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/SingleSignOnEnabled/metric.rego
+++ b/policies/bundles/SingleSignOnEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.single_sign_on_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/bundles/TLSVersion/metric.rego
+++ b/policies/bundles/TLSVersion/metric.rego
@@ -1,4 +1,7 @@
-package clouditor
+package clouditor.metrics.tls_version
+
+import data.clouditor.compare
+import data.clouditor.isIn
 
 default compliant = false
 

--- a/policies/bundles/TransportEncryptionAlgorithm/input.json
+++ b/policies/bundles/TransportEncryptionAlgorithm/input.json
@@ -1,0 +1,14 @@
+{
+    "name": "/object",
+    "id": "someObject",
+    "type": [
+        "ObjectStorage"
+    ],
+    "httpEndpoint": {
+        "url": "clouditor.io",
+        "transportEncryption": {
+            "enabled": true,
+            "algorithm": "TLS"
+        }
+    }
+}

--- a/policies/bundles/TransportEncryptionAlgorithm/metric.rego
+++ b/policies/bundles/TransportEncryptionAlgorithm/metric.rego
@@ -1,10 +1,11 @@
-package clouditor
+package clouditor.metrics.transport_encryption_algorithm
+
+import data.clouditor.compare
+import input.httpEndpoint as endpoint
 
 default compliant = false
 
 default applicable = false
-
-endpoint := input.httpEndpoint
 
 applicable {
 	endpoint

--- a/policies/bundles/TransportEncryptionEnabled/metric.rego
+++ b/policies/bundles/TransportEncryptionEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.transport_encryption_enabled
+
+import data.clouditor.compare
 
 default compliant = false
 

--- a/policies/bundles/TransportEncryptionEnforced/metric.rego
+++ b/policies/bundles/TransportEncryptionEnforced/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.transport_encryption_enforced
+
+import data.clouditor.compare
 
 default compliant = false
 

--- a/policies/bundles/WebApplicationFirewallEnabled/metric.rego
+++ b/policies/bundles/WebApplicationFirewallEnabled/metric.rego
@@ -1,4 +1,6 @@
-package clouditor
+package clouditor.metrics.web_application_firewall_enabled
+
+import data.clouditor.compare
 
 default applicable = false
 

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -51,6 +51,7 @@ type Result struct {
 	MetricId    string
 }
 
+// MetricConfigurationSource can be used to retrieve a metric configuration for a particular metric (and target service)
 type MetricConfigurationSource interface {
 	MetricConfiguration(metric string) (*assessment.MetricConfiguration, error)
 }

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -263,8 +263,8 @@ func TestRunEvidence(t *testing.T) {
 			}
 			assert.NotEmpty(t, results)
 			for _, result := range results {
-				assert.Equal(t, tt.applicable, result["applicable"].(bool))
-				assert.Equal(t, tt.compliant, result["compliant"].(bool))
+				assert.Equal(t, tt.applicable, result.Applicable)
+				assert.Equal(t, tt.compliant, result.Compliant)
 			}
 		})
 	}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -26,11 +26,15 @@
 package policies
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"clouditor.io/clouditor/voc"
+	"google.golang.org/protobuf/encoding/protojson"
 
+	"clouditor.io/clouditor/api/assessment"
 	"clouditor.io/clouditor/api/evidence"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,9 +65,13 @@ func TestRunEvidence(t *testing.T) {
 		resource   voc.IsCloudResource
 		evidenceID string
 	}
+	type args struct {
+		source MetricConfigurationSource
+	}
 	tests := []struct {
 		name       string
 		fields     fields
+		args       args
 		applicable bool
 		compliant  bool
 		wantErr    bool
@@ -104,6 +112,7 @@ func TestRunEvidence(t *testing.T) {
 				},
 				evidenceID: mockObjStorage1EvidenceID,
 			},
+			args:       args{source: &mockMetricConfigurationSource{t: t}},
 			applicable: true,
 			compliant:  true,
 			wantErr:    false,
@@ -140,6 +149,7 @@ func TestRunEvidence(t *testing.T) {
 				},
 				evidenceID: mockObjStorage2EvidenceID,
 			},
+			args:       args{source: &mockMetricConfigurationSource{t: t}},
 			applicable: true,
 			compliant:  false,
 			wantErr:    false,
@@ -180,6 +190,7 @@ func TestRunEvidence(t *testing.T) {
 				},
 				evidenceID: mockObjStorage2EvidenceID,
 			},
+			args:       args{source: &mockMetricConfigurationSource{t: t}},
 			applicable: true,
 			compliant:  false,
 			wantErr:    false,
@@ -212,6 +223,7 @@ func TestRunEvidence(t *testing.T) {
 				},
 				evidenceID: mockVM1EvidenceID,
 			},
+			args:       args{source: &mockMetricConfigurationSource{t: t}},
 			applicable: true,
 			compliant:  true,
 			wantErr:    false,
@@ -244,6 +256,7 @@ func TestRunEvidence(t *testing.T) {
 				},
 				evidenceID: mockVM2EvidenceID,
 			},
+			args:       args{source: &mockMetricConfigurationSource{t: t}},
 			applicable: true,
 			compliant:  false,
 			wantErr:    false,
@@ -256,7 +269,7 @@ func TestRunEvidence(t *testing.T) {
 			results, err := RunEvidence(&evidence.Evidence{
 				Id:       tt.fields.evidenceID,
 				Resource: resource,
-			})
+			}, tt.args.source)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RunEvidence() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -268,4 +281,25 @@ func TestRunEvidence(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockMetricConfigurationSource struct {
+	t *testing.T
+}
+
+func (m *mockMetricConfigurationSource) MetricConfiguration(metric string) (*assessment.MetricConfiguration, error) {
+	// Fetch the metric configuration directly from our file
+
+	bundle := fmt.Sprintf("policies/bundles/%s/data.json", metric)
+	file, err := os.OpenFile(bundle, os.O_RDONLY, 0600)
+	assert.NoError(m.t, err)
+
+	b, err := ioutil.ReadAll(file)
+	assert.NoError(m.t, err)
+
+	var config assessment.MetricConfiguration
+	err = protojson.Unmarshal(b, &config)
+	assert.NoError(m.t, err)
+
+	return &config, nil
 }

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -223,14 +223,12 @@ func (s *Service) handleEvidence(evidence *evidence.Evidence, resourceId string)
 	}
 
 	for i, data := range evaluations {
-		metricId := data["metricId"].(string)
+		metricId := data.MetricId
 
-		log.Infof("Evaluated evidence with metric '%v' as %v", metricId, data["compliant"])
+		log.Infof("Evaluated evidence with metric '%v' as %v", metricId, data.Compliant)
 
 		// Get output values of Rego evaluation. If they are not given, the zero value is used
-		operator, _ := data["operator"].(string)
-		targetValue := data["target_value"]
-		compliant, _ := data["compliant"].(bool)
+		targetValue := data.TargetValue
 
 		convertedTargetValue, err := convertTargetValue(targetValue)
 		if err != nil {
@@ -243,9 +241,9 @@ func (s *Service) handleEvidence(evidence *evidence.Evidence, resourceId string)
 			MetricId:  metricId,
 			MetricConfiguration: &assessment.MetricConfiguration{
 				TargetValue: convertedTargetValue,
-				Operator:    operator,
+				Operator:    data.Operator,
 			},
-			Compliant:             compliant,
+			Compliant:             data.Compliant,
 			EvidenceId:            evidence.Id,
 			ResourceId:            resourceId,
 			NonComplianceComments: "No comments so far",

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -76,6 +76,8 @@ type Service struct {
 	// Currently, results are just stored as a map (=in-memory). In the future, we will use a DB.
 	results map[string]*assessment.AssessmentResult
 
+	cachedConfigurations map[string]*assessment.MetricConfiguration
+
 	authorizer api.Authorizer
 }
 
@@ -203,10 +205,10 @@ func (s *Service) AssessEvidences(stream assessment.Assessment_AssessEvidencesSe
 
 // handleEvidence is the helper method for the actual assessment used by AssessEvidence and AssessEvidences
 func (s *Service) handleEvidence(evidence *evidence.Evidence, resourceId string) (err error) {
-	log.Infof("Running evidence %s (%s) collected by %s at %v", evidence.Id, resourceId, evidence.ToolId, evidence.Timestamp)
+	log.Infof("Evaluating evidence %s (%s) collected by %s at %v", evidence.Id, resourceId, evidence.ToolId, evidence.Timestamp)
 	log.Debugf("Evidence: %+v", evidence)
 
-	evaluations, err := policies.RunEvidence(evidence)
+	evaluations, err := policies.RunEvidence(evidence, s)
 	if err != nil {
 		newError := fmt.Errorf("could not evaluate evidence: %w", err)
 		log.Errorf(newError.Error())
@@ -381,5 +383,9 @@ func (s *Service) sendToOrchestrator(result *assessment.AssessmentResult) error 
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (s *Service) FetchMetricConfiguration(metric string) *assessment.MetricConfiguration {
 	return nil
 }

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -58,7 +58,7 @@ func init() {
 
 const (
 	// EvictionTime is the time after which an entry in the metric configuration is invalid
-	EvictionTime = time.Minute * 5
+	EvictionTime = time.Hour * 1
 )
 
 type cachedConfiguration struct {
@@ -90,8 +90,8 @@ type Service struct {
 	// Currently, results are just stored as a map (=in-memory). In the future, we will use a DB.
 	results map[string]*assessment.AssessmentResult
 
-    // cachedConfigurations holds cached metric configurations for faster access with key being the corresponding
-    // metric name
+	// cachedConfigurations holds cached metric configurations for faster access with key being the corresponding
+	// metric name
 	cachedConfigurations map[string]cachedConfiguration
 
 	authorizer api.Authorizer

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -85,6 +85,7 @@ func TestNewService(t *testing.T) {
 				results:              make(map[string]*assessment.AssessmentResult),
 				evidenceStoreAddress: "localhost:9090",
 				orchestratorAddress:  "localhost:9090",
+				cachedConfigurations: make(map[string]*assessment.MetricConfiguration),
 			},
 		},
 		{
@@ -99,6 +100,7 @@ func TestNewService(t *testing.T) {
 				results:              make(map[string]*assessment.AssessmentResult),
 				evidenceStoreAddress: "localhost:9091",
 				orchestratorAddress:  "localhost:9092",
+				cachedConfigurations: make(map[string]*assessment.MetricConfiguration),
 			},
 		},
 	}
@@ -292,6 +294,7 @@ func TestAssessEvidences(t *testing.T) {
 			s := Service{
 				resultHooks:                   tt.fields.ResultHooks,
 				results:                       tt.fields.results,
+				cachedConfigurations:          make(map[string]*assessment.MetricConfiguration),
 				UnimplementedAssessmentServer: tt.fields.UnimplementedAssessmentServer,
 			}
 			if tt.fields.hasRPCConnection {
@@ -693,7 +696,6 @@ func TestHandleEvidence(t *testing.T) {
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				assert.Error(t, err)
 				// Check if error message contains "empty" (list of types)
-				assert.Contains(t, err.Error(), "Orchestrator")
 				assert.Contains(t, err.Error(), "Unavailable desc")
 				return true
 			},

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -40,6 +40,7 @@ import (
 	"clouditor.io/clouditor/api/assessment"
 	"clouditor.io/clouditor/api/evidence"
 	"clouditor.io/clouditor/voc"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -85,7 +86,7 @@ func TestNewService(t *testing.T) {
 				results:              make(map[string]*assessment.AssessmentResult),
 				evidenceStoreAddress: "localhost:9090",
 				orchestratorAddress:  "localhost:9090",
-				cachedConfigurations: make(map[string]*assessment.MetricConfiguration),
+				cachedConfigurations: make(map[string]cachedConfiguration),
 			},
 		},
 		{
@@ -100,7 +101,7 @@ func TestNewService(t *testing.T) {
 				results:              make(map[string]*assessment.AssessmentResult),
 				evidenceStoreAddress: "localhost:9091",
 				orchestratorAddress:  "localhost:9092",
-				cachedConfigurations: make(map[string]*assessment.MetricConfiguration),
+				cachedConfigurations: make(map[string]cachedConfiguration),
 			},
 		},
 	}
@@ -294,7 +295,7 @@ func TestAssessEvidences(t *testing.T) {
 			s := Service{
 				resultHooks:                   tt.fields.ResultHooks,
 				results:                       tt.fields.results,
-				cachedConfigurations:          make(map[string]*assessment.MetricConfiguration),
+				cachedConfigurations:          make(map[string]cachedConfiguration),
 				UnimplementedAssessmentServer: tt.fields.UnimplementedAssessmentServer,
 			}
 			if tt.fields.hasRPCConnection {

--- a/service/orchestrator/metrics.json
+++ b/service/orchestrator/metrics.json
@@ -130,6 +130,9 @@
     ]
   },
   {
+    "id": "TransportEncryptionEnforced"
+  },
+  {
     "id": "WebApplicationFirewallEnabled"
   }
 ]

--- a/service/orchestrator/orchestrator.go
+++ b/service/orchestrator/orchestrator.go
@@ -241,7 +241,6 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 			return err
 		}
 	}
-
 }
 
 // ListAssessmentResults is a method implementation of the orchestrator interface


### PR DESCRIPTION
This PR ties in the metric configuration with the Repo evaluation. It introduces a new interfaces called `MetricConfigurationSource`, which is expected by the `RunEvidence` function. 

This interface can be used to retrieve a metric configuration for a particular metric (and target service). Currently, only the default cloud target service is used, as not every micro-service is aware of the target cloud service (yet). Currently, the assessment service implements this interfaces and fetches the metric configurations from the orchestrator (and caches them). 

In the future, we need a proper way to evict that cache based on an event (such as the configuration of a target cloud service changed).