### PR TITLE
Fix Dockerfile: Use right gnostic package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go \
 ADD . .
 
 RUN go generate ./...
-RUN go build ./...
+RUN go build -o /build/engine cmd/engine/engine.go
+RUN go build -o /build/cl cmd/cli/cl.go
 
 FROM debian:stable-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && apt install -y protobuf-compiler
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go \
     google.golang.org/grpc/cmd/protoc-gen-go-grpc \
     github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
-    github.com/googleapis/gnostic/apps/protoc-gen-openapi
+    github.com/google/gnostic/cmd/protoc-gen-openapi
 
 ADD . .
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Also make sure that `$HOME/go/bin` is on your `$PATH` and build:
 
 ```
 go generate ./...
-go build ./...
+go build -o ./engine cmd/engine/engine.go
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes #574. I also fixed the build instructions in the DOCKERFILE since the `copy` command (e.g. `COPY --from=builder /build/engine /`) couldn't find the build binaries.