### PR TITLE
Performance and concurrency improvements in assessment

### DIFF
--- a/api/assessment/metric.go
+++ b/api/assessment/metric.go
@@ -1,8 +1,10 @@
 package assessment
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 )
 
 var (
@@ -68,4 +70,10 @@ func (m *Metric) Validate(opts ...MetricValidationOption) (err error) {
 	}
 
 	return nil
+}
+
+// Hash provides a simple string based hash for this metric configuration. It can be used
+// to provide a key for a map or a cache.
+func (x *MetricConfiguration) Hash() string {
+	return base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%v-%v", x.Operator, x.TargetValue)))
 }

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -238,8 +238,8 @@ func (s *Service) AssessEvidences(stream assessment.Assessment_AssessEvidencesSe
 
 // handleEvidence is the helper method for the actual assessment used by AssessEvidence and AssessEvidences
 func (s *Service) handleEvidence(evidence *evidence.Evidence, resourceId string) (err error) {
-	log.Infof("Evaluating evidence %s (%s) collected by %s at %v", evidence.Id, resourceId, evidence.ToolId, evidence.Timestamp)
-	log.Debugf("Evidence: %+v", evidence)
+	log.Debugf("Evaluating evidence %s (%s) collected by %s at %v", evidence.Id, resourceId, evidence.ToolId, evidence.Timestamp)
+	log.Tracef("Evidence: %+v", evidence)
 
 	evaluations, err := policies.RunEvidence(evidence, s)
 	if err != nil {
@@ -260,7 +260,7 @@ func (s *Service) handleEvidence(evidence *evidence.Evidence, resourceId string)
 	for i, data := range evaluations {
 		metricId := data.MetricId
 
-		log.Infof("Evaluated evidence with metric '%v' as %v", metricId, data.Compliant)
+		log.Debugf("Evaluated evidence with metric '%v' as %v", metricId, data.Compliant)
 
 		targetValue := data.TargetValue
 
@@ -391,7 +391,7 @@ func (s *Service) sendToEvidenceStore(e *evidence.Evidence) error {
 		}
 	}
 
-	log.Infof("Sending evidence (%v) to Evidence Store", e.Id)
+	log.Debugf("Sending evidence (%v) to Evidence Store", e.Id)
 
 	err := s.evidenceStoreStream.Send(&evidence.StoreEvidenceRequest{Evidence: e})
 	if err != nil {
@@ -448,7 +448,7 @@ func (s *Service) sendToOrchestrator(result *assessment.AssessmentResult) error 
 		}
 	}
 
-	log.Infof("Sending assessment result (%v) to Orchestrator", result.Id)
+	log.Debugf("Sending assessment result (%v) to Orchestrator", result.Id)
 
 	req := &orchestrator.StoreAssessmentResultRequest{
 		Result: result,

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -208,7 +208,7 @@ func (s *Service) AssessEvidences(stream assessment.Assessment_AssessEvidencesSe
 		req, err = stream.Recv()
 
 		// If no more input of the stream is available, return
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
@@ -228,6 +228,11 @@ func (s *Service) AssessEvidences(stream assessment.Assessment_AssessEvidencesSe
 
 		// Send response back to the client
 		err = stream.Send(res)
+
+		// Check for send errors
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 		if err != nil {
 			newError := fmt.Errorf("cannot send response to the client: %w", err)
 			log.Error(newError)
@@ -366,7 +371,7 @@ func (s *Service) initEvidenceStoreStream(additionalOpts ...grpc.DialOption) err
 	go func() {
 		for {
 			_, err := s.evidenceStoreStream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 
@@ -423,7 +428,7 @@ func (s *Service) initOrchestratorStream(additionalOpts ...grpc.DialOption) erro
 	go func() {
 		for {
 			_, err := s.orchestratorStream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 

--- a/service/assessment/benchmark_test.go
+++ b/service/assessment/benchmark_test.go
@@ -21,14 +21,14 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func createSome(n int, m int, b *testing.B) int {
+func createEvidences(n int, m int, b *testing.B) int {
 	var (
 		wg   sync.WaitGroup
 		err  error
 		sock net.Listener
 	)
 
-	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetLevel(logrus.InfoLevel)
 
 	srv := grpc.NewServer()
 
@@ -113,7 +113,7 @@ func createSome(n int, m int, b *testing.B) int {
 
 func benchmarkAssessEvidence(i int, m int, b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		createSome(i, m, b)
+		createEvidences(i, m, b)
 	}
 }
 

--- a/service/assessment/benchmark_test.go
+++ b/service/assessment/benchmark_test.go
@@ -1,0 +1,97 @@
+package assessment
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"clouditor.io/clouditor/api/assessment"
+	"clouditor.io/clouditor/api/evidence"
+	"clouditor.io/clouditor/voc"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func createSome(n int, b *testing.B) int {
+	var wg sync.WaitGroup
+
+	wg.Add(n * 7)
+
+	svc := NewService(WithOrchestratorAddress("bufcon"))
+	svc.initOrchestratorStream(grpc.WithContextDialer(bufConnDialer))
+	svc.initEvidenceStoreStream(grpc.WithContextDialer(bufConnDialer))
+	svc.RegisterAssessmentResultHook(func(result *assessment.AssessmentResult, err error) {
+		wg.Done()
+	})
+
+	// Create evidences for n resources (1 per resource)
+	for i := 0; i < n; i++ {
+		r, _ := voc.ToStruct(&voc.VirtualMachine{Compute: &voc.Compute{Resource: &voc.Resource{
+			ID:   voc.ResourceID(fmt.Sprintf("%d", i)),
+			Type: []string{"VirtualMachine", "Compute", "Resource"},
+		}}})
+
+		e := evidence.Evidence{
+			Id:        uuid.NewString(),
+			Timestamp: timestamppb.Now(),
+			ToolId:    "mytool",
+			Resource:  r,
+		}
+
+		if i%100 == 0 || i > 2700 {
+			log.Infof("Currently @ %v", i)
+		}
+		if i == 2782 {
+			fmt.Printf("last call")
+		}
+
+		_, err := svc.AssessEvidence(context.Background(), &assessment.AssessEvidenceRequest{
+			Evidence: &e,
+		})
+		if err != nil {
+			b.Errorf("Error while calling AssessEvidence: %v", err)
+		}
+	}
+
+	wg.Wait()
+	svc.orchestratorStream.CloseSend()
+	svc.evidenceStoreStream.CloseSend()
+
+	return 0
+}
+
+func benchmarkAssessEvidence(i int, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		createSome(i, b)
+	}
+}
+
+func BenchmarkAssessEvidence1(b *testing.B) {
+	benchmarkAssessEvidence(1, b)
+}
+
+func BenchmarkAssessEvidence2(b *testing.B) {
+	benchmarkAssessEvidence(2, b)
+}
+
+func BenchmarkAssessEvidence10(b *testing.B) {
+	benchmarkAssessEvidence(10, b)
+}
+
+func BenchmarkAssessEvidence100(b *testing.B) {
+	benchmarkAssessEvidence(100, b)
+}
+
+func BenchmarkAssessEvidence1000(b *testing.B) {
+	benchmarkAssessEvidence(1000, b)
+}
+
+func BenchmarkAssessEvidence3000(b *testing.B) {
+	benchmarkAssessEvidence(3000, b)
+}
+
+func BenchmarkAssessEvidence10000(b *testing.B) {
+	benchmarkAssessEvidence(10000, b)
+}

--- a/service/assessment/bufconn_test.go
+++ b/service/assessment/bufconn_test.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
-const DefaultBufferSize = 1024 * 1024 * 10
+const DefaultBufferSize = 1024 * 1024
 
 var (
 	bufConnListener *bufconn.Listener

--- a/service/assessment/bufconn_test.go
+++ b/service/assessment/bufconn_test.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
-const DefaultBufferSize = 1024 * 1024
+const DefaultBufferSize = 1024 * 1024 * 10
 
 var (
 	bufConnListener *bufconn.Listener

--- a/service/discovery/discovery.go
+++ b/service/discovery/discovery.go
@@ -175,7 +175,7 @@ func (s *Service) initAssessmentStream(additionalOpts ...grpc.DialOption) error 
 	go func() {
 		for {
 			_, err := s.assessmentStream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -88,7 +88,7 @@ func (s *Service) StoreEvidence(_ context.Context, req *evidence.StoreEvidenceRe
 		Status: true,
 	}
 
-	log.Infof("Evidence stored with id: %v", req.Evidence.Id)
+	log.Debugf("Evidence stored with id: %v", req.Evidence.Id)
 
 	return resp, nil
 }

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -27,6 +27,7 @@ package evidences
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -104,7 +105,7 @@ func (s *Service) StoreEvidences(stream evidence.EvidenceStore_StoreEvidencesSer
 		req, err = stream.Recv()
 
 		// If no more input of the stream is available, return
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
@@ -126,7 +127,7 @@ func (s *Service) StoreEvidences(stream evidence.EvidenceStore_StoreEvidencesSer
 		err = stream.Send(res)
 
 		// Check for send errors
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -112,6 +112,7 @@ func (s *Service) StoreEvidences(stream evidence.EvidenceStore_StoreEvidencesSer
 			log.Error(newError)
 			return status.Errorf(codes.Unknown, "%v", newError)
 		}
+
 		// Call StoreEvidence() for storing a single evidence
 		evidenceRequest := &evidence.StoreEvidenceRequest{
 			Evidence: req.Evidence,
@@ -123,6 +124,11 @@ func (s *Service) StoreEvidences(stream evidence.EvidenceStore_StoreEvidencesSer
 
 		// Send response back to the client
 		err = stream.Send(res)
+
+		// Check for send errors
+		if err == io.EOF {
+			return nil
+		}
 		if err != nil {
 			newError := fmt.Errorf("cannot send response to the client: %w", err)
 			log.Error(newError)

--- a/service/orchestrator/orchestrator.go
+++ b/service/orchestrator/orchestrator.go
@@ -252,7 +252,6 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 		if err == io.EOF {
 			return nil
 		}
-
 		if err != nil {
 			newError := fmt.Errorf("cannot receive stream request: %w", err)
 			log.Error(newError)
@@ -269,6 +268,11 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 		}
 
 		err = stream.Send(res)
+
+		// Check for send errors
+		if err == io.EOF {
+			return nil
+		}
 		if err != nil {
 			newError := fmt.Errorf("cannot stream response to the client: %w", err)
 			log.Error(newError)

--- a/service/orchestrator/orchestrator.go
+++ b/service/orchestrator/orchestrator.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -249,7 +250,7 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 		result, err = stream.Recv()
 
 		// If no more input of the stream is available, return
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
@@ -270,7 +271,7 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 		err = stream.Send(res)
 
 		// Check for send errors
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {


### PR DESCRIPTION
This PR adds a major performance improvement to the policy checking implementation. Instead of creating a new Rego query for each evaluation, we are using a `queryCache` struct to cache the prepared query for each metric (and its metric configuration).

This boots metric evaluation speed by roughly 10x.