### PR TITLE
Fix initXXXStream error

### DIFF
--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -189,36 +189,16 @@ func (s *Service) AssessEvidence(_ context.Context, req *assessment.AssessEviden
 	// Check if evidence store stream exists
 	if s.evidenceStoreStream == nil {
 		err = s.initEvidenceStoreStream()
-
 		if err != nil {
-			newError := fmt.Errorf("error initialising evidence store stream: %w", err)
-			log.Error(newError)
-			s.informHooks(nil, newError)
-
-			res = &assessment.AssessEvidenceResponse{
-				Status:        assessment.AssessEvidenceResponse_FAILED,
-				StatusMessage: newError.Error(),
-			}
-
-			return res, status.Errorf(codes.Internal, "%v", newError)
+			log.Errorf("error initialising evidence store stream: %v", err)
 		}
 	}
 
 	// Check if orchestrator stream exists
 	if s.orchestratorStream == nil {
 		err = s.initOrchestratorStream()
-
 		if err != nil {
-			newError := fmt.Errorf("error initialising orchestrator stream: %w", err)
-			log.Error(newError)
-			s.informHooks(nil, newError)
-
-			res = &assessment.AssessEvidenceResponse{
-				Status:        assessment.AssessEvidenceResponse_FAILED,
-				StatusMessage: newError.Error(),
-			}
-
-			return res, status.Errorf(codes.Internal, "%v", newError)
+			log.Errorf("error initialising orchestrator stream: %v", err)
 		}
 	}
 

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -155,18 +155,6 @@ func NewService(opts ...ServiceOption) *Service {
 		o(s)
 	}
 
-	// Initialise Evidence Store stream
-	err := s.initEvidenceStoreStream()
-	if err != nil {
-		log.Errorf("Error while initializing evidence store stream: %v", err)
-	}
-
-	// Initialise Orchestrator stream
-	err = s.initOrchestratorStream()
-	if err != nil {
-		log.Errorf("Error while initializing orchestrator stream: %v", err)
-	}
-
 	return s
 }
 
@@ -196,6 +184,23 @@ func (s *Service) AssessEvidence(_ context.Context, req *assessment.AssessEviden
 		}
 
 		return res, status.Errorf(codes.InvalidArgument, "%v", newError)
+	}
+
+	// Check if evidence store stream exists
+	if s.evidenceStoreStream == nil {
+		err = s.initEvidenceStoreStream()
+		if err != nil {
+			log.Errorf("error initialising evidence store stream: %v", err)
+		}
+	}
+
+	// Check if orchestrator stream exists
+	if s.orchestratorStream == nil {
+		err = s.initOrchestratorStream()
+
+		if err != nil {
+			log.Errorf("error initialising orchestrator stream: %v", err)
+		}
 	}
 
 	// Assess evidence

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -189,8 +189,18 @@ func (s *Service) AssessEvidence(_ context.Context, req *assessment.AssessEviden
 	// Check if evidence store stream exists
 	if s.evidenceStoreStream == nil {
 		err = s.initEvidenceStoreStream()
+
 		if err != nil {
-			log.Errorf("error initialising evidence store stream: %v", err)
+			newError := fmt.Errorf("error initialising evidence store stream: %w", err)
+			log.Error(newError)
+			s.informHooks(nil, newError)
+
+			res = &assessment.AssessEvidenceResponse{
+				Status:        assessment.AssessEvidenceResponse_FAILED,
+				StatusMessage: newError.Error(),
+			}
+
+			return res, status.Errorf(codes.Internal, "%v", newError)
 		}
 	}
 
@@ -199,7 +209,16 @@ func (s *Service) AssessEvidence(_ context.Context, req *assessment.AssessEviden
 		err = s.initOrchestratorStream()
 
 		if err != nil {
-			log.Errorf("error initialising orchestrator stream: %v", err)
+			newError := fmt.Errorf("error initialising orchestrator stream: %w", err)
+			log.Error(newError)
+			s.informHooks(nil, newError)
+
+			res = &assessment.AssessEvidenceResponse{
+				Status:        assessment.AssessEvidenceResponse_FAILED,
+				StatusMessage: newError.Error(),
+			}
+
+			return res, status.Errorf(codes.Internal, "%v", newError)
 		}
 	}
 

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -205,6 +205,24 @@ func TestAssessEvidence(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "No RPC connections",
+			args: args{
+				in0: context.TODO(),
+				evidence: &evidence.Evidence{
+					Id:        "11111111-1111-1111-1111-111111111111",
+					ToolId:    "mock",
+					Timestamp: timestamppb.Now(),
+					Resource:  toStruct(voc.VirtualMachine{Compute: &voc.Compute{Resource: &voc.Resource{ID: "my-resource-id", Type: []string{"VirtualMachine"}}}}, t),
+				},
+			},
+			hasRPCConnection: false,
+			wantResp: &assessment.AssessEvidenceResponse{
+				Status:        assessment.AssessEvidenceResponse_FAILED,
+				StatusMessage: "error initialising evidence store stream: could not set up stream for storing evidences: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: missing address\"",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -219,7 +219,7 @@ func TestAssessEvidence(t *testing.T) {
 			hasRPCConnection: false,
 			wantResp: &assessment.AssessEvidenceResponse{
 				Status:        assessment.AssessEvidenceResponse_FAILED,
-				StatusMessage: "error initialising evidence store stream: could not set up stream for storing evidences: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: missing address\"",
+				StatusMessage: "could not evaluate evidence: could not fetch metric configuration: could not retrieve metric configuration for",
 			},
 			wantErr: true,
 		},
@@ -238,14 +238,15 @@ func TestAssessEvidence(t *testing.T) {
 			}
 
 			gotResp, err := s.AssessEvidence(tt.args.in0, &assessment.AssessEvidenceRequest{Evidence: tt.args.evidence})
+
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AssessEvidence() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			if !reflect.DeepEqual(gotResp, tt.wantResp) {
-				t.Errorf("AssessEvidence() gotResp = %v, want %v", gotResp, tt.wantResp)
-			}
+			// Check response
+			assert.Equal(t, tt.wantResp.Status, gotResp.Status)
+			assert.Contains(t, gotResp.StatusMessage, tt.wantResp.StatusMessage)
 		})
 	}
 }

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -112,13 +112,10 @@ func TestNewService(t *testing.T) {
 			// Check channels have been created
 			assert.NotNil(t, s.evidenceStoreChannel)
 			assert.NotNil(t, s.orchestratorChannel)
-			assert.NotNil(t, s.orchestratorClient)
 
 			// Ignore pointers to channel in subsequent DeepEqual check
 			s.evidenceStoreChannel = nil
 			s.orchestratorChannel = nil
-			// Ignore pointer to orchestrator client in subsequent DeepEqual check
-			s.orchestratorClient = nil
 
 			if got := s; !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewService() = %v, want %v", got, tt.want)


### PR DESCRIPTION
initXXXStream was called in NewService(). The problem is, that in engine.go NewService() is called before the server are running, thus the initXXXStream methods always fail. 

For now I moved the initXXXStream() calls from NewService() to AssessEvidence(). It is checked if  a stream exists and if not, the streams are initialized. 

It is not very nice, but it was the fastest solution. 