### PR TITLE
Add issues to dev board automatically

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   issue_opened:
-    name: issue_opened_or_reopened
     runs-on: ubuntu-latest
     steps:
       - name: Move issue to Someday


### PR DESCRIPTION
This PR adds a GitHub automation workflow that automatically assigns new issues into the Clouditor Development project. Currently, this applies to *all* issues; if this gets too much we might want to filter it, e.g. exclude bug issues.