### PR TITLE
Implementing maximum concurrent connections for storage

### DIFF
--- a/persistence/inmemory/inmemory.go
+++ b/persistence/inmemory/inmemory.go
@@ -6,11 +6,13 @@ import (
 	"gorm.io/gorm/logger"
 )
 
-// NewStorage creates a new in-memory storage. For now this uses the gorm provider
-// with the gorm.WithInMemory. In the future we want to supply our own independent
-// implementation.
+// NewStorage creates a new in-memory storage. For now this uses the gorm provider with the gorm.WithInMemory. In the
+// future we want to supply our own independent implementation. It automatically sets the maximum concurrent connections
+// to 1 because the in-memory sqlite driver has problems with more than concurrent connection (see
+// https://github.com/mattn/go-sqlite3/issues/511).
 func NewStorage() (persistence.Storage, error) {
 	return gorm.NewStorage(
 		gorm.WithInMemory(),
+		gorm.WithMaxOpenConns(1),
 		gorm.WithLogger(logger.Default.LogMode(logger.Silent)))
 }


### PR DESCRIPTION
This needs to be enforced to 1 for our in-memory database, otherwise `no such table` errors are creeping up. See https://github.com/mattn/go-sqlite3/issues/511 for more details.
