### PR TITLE
Implementing `RequirementsSource` in assessment service

### DIFF
--- a/policies/policies.go
+++ b/policies/policies.go
@@ -68,6 +68,11 @@ type MetricsSource interface {
 	MetricImplementation(lang assessment.MetricImplementation_Language, metric string) (*assessment.MetricImplementation, error)
 }
 
+// RequirementsSource is used to retrieve a list of requirements
+type RequirementsSource interface {
+	Requirements() ([]*orchestrator.Requirement, error)
+}
+
 // createKey creates a key by concatenating toolID and all types
 func createKey(toolID string, types []string) (key string) {
 	// Merge toolID and types to one slice and concatenate all its elements

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -507,7 +507,7 @@ func (svc *Service) Metrics() (metrics []*assessment.Metric, err error) {
 
 	err = svc.initOrchestratorClient()
 	if err != nil {
-		return nil, fmt.Errorf("could not set orchestrator client")
+		return nil, fmt.Errorf("could not init orchestrator client")
 	}
 
 	res, err = svc.orchestratorClient.ListMetrics(context.Background(), &orchestrator.ListMetricsRequest{})
@@ -516,6 +516,23 @@ func (svc *Service) Metrics() (metrics []*assessment.Metric, err error) {
 	}
 
 	return res.Metrics, nil
+}
+
+// Requirements implements RequirementsSource by retrieving the requirement list from the orchestrator.
+func (svc *Service) Requirements() (requirements []*orchestrator.Requirement, err error) {
+	var res *orchestrator.ListRequirementsResponse
+
+	err = svc.initOrchestratorClient()
+	if err != nil {
+		return nil, fmt.Errorf("could not init orchestrator client")
+	}
+
+	res, err = svc.orchestratorClient.ListRequirements(context.Background(), &orchestrator.ListRequirementsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve metric list from orchestrator: %w", err)
+	}
+
+	return res.Requirements, nil
 }
 
 // MetricImplementation implements MetricsSource by retrieving the metric implementation


### PR DESCRIPTION
This helps users that use the assessment service as an API to conveniently retrieve a list of requirements from the Orchestrator without the need to establish another gRPC client. 