### PR TITLE
Fixed flakey discovery test

### DIFF
--- a/service/discovery/discovery_test.go
+++ b/service/discovery/discovery_test.go
@@ -615,14 +615,14 @@ func (*mockAssessmentStream) Context() context.Context {
 }
 
 func (m *mockAssessmentStream) SendMsg(req interface{}) (err error) {
-	m.wg.Done()
-
 	e := req.(*assessment.AssessEvidenceRequest).Evidence
 	if m.connectionEstablished {
 		m.sentEvidences = append(m.sentEvidences, e)
 	} else {
 		err = fmt.Errorf("mock send error")
 	}
+
+	m.wg.Done()
 
 	return
 }


### PR DESCRIPTION
`wg.Done` was in the wrong place.
