### PR TITLE
Fixes all ports to be `uint16`

### DIFF
--- a/api/authorizer_test.go
+++ b/api/authorizer_test.go
@@ -42,7 +42,7 @@ import (
 func Test_oauthAuthorizer_Token(t *testing.T) {
 	var (
 		srv  *oauth2.AuthorizationServer
-		port int
+		port uint16
 		err  error
 	)
 	srv, port, err = testutil.StartAuthenticationServer()

--- a/cli/commands/cloud/cloud_test.go
+++ b/cli/commands/cloud/cloud_test.go
@@ -280,8 +280,8 @@ func TestGetMetricConfiguration(t *testing.T) {
 func startServer(opts ...service.StartGRPCServerOption) (tmpDir string, auth *oauth2.AuthorizationServer, srv *grpc.Server) {
 	var (
 		err      error
-		grpcPort int
-		authPort int
+		grpcPort uint16
+		authPort uint16
 		sock     net.Listener
 	)
 
@@ -295,7 +295,7 @@ func startServer(opts ...service.StartGRPCServerOption) (tmpDir string, auth *oa
 		panic(err)
 	}
 
-	grpcPort = sock.Addr().(*net.TCPAddr).Port
+	grpcPort = sock.Addr().(*net.TCPAddr).AddrPort().Port()
 
 	tmpDir, err = clitest.PrepareSession(authPort, auth, fmt.Sprintf("localhost:%d", grpcPort))
 	if err != nil {

--- a/cli/commands/login/login_test.go
+++ b/cli/commands/login/login_test.go
@@ -67,7 +67,7 @@ func TestLogin(t *testing.T) {
 		dir      string
 		verifier string
 		authSrv  *oauth2.AuthorizationServer
-		port     int
+		port     uint16
 	)
 
 	authSrv, port, err = testutil.StartAuthenticationServer()
@@ -110,7 +110,7 @@ func TestLogin(t *testing.T) {
 			}
 		}()
 
-		err = cmd.RunE(nil, []string{fmt.Sprintf("localhost:%d", sock.Addr().(*net.TCPAddr).Port)})
+		err = cmd.RunE(nil, []string{fmt.Sprintf("localhost:%d", sock.Addr().(*net.TCPAddr).AddrPort().Port())})
 		assert.NoError(t, err)
 		done <- true
 	}()

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -94,7 +94,7 @@ const (
 
 	DefaultAPIDefaultUser               = "clouditor"
 	DefaultAPIDefaultPassword           = "clouditor"
-	DefaultAPIgRPCPort                  = 9090
+	DefaultAPIgRPCPort                  = uint16(9090)
 	DefaultAPIStartEmbeddedOAuth2Server = true
 	DefaultServiceOAuth2Endpoint        = "http://localhost:8080/v1/auth/token"
 	DefaultServiceOAuth2ClientID        = "clouditor"
@@ -103,7 +103,7 @@ const (
 	DefaultDBPassword                   = "postgres"
 	DefaultDBHost                       = "localhost"
 	DefaultDBName                       = "postgres"
-	DefaultDBPort                       = 5432
+	DefaultDBPort                       = uint16(5432)
 	DefaultDBInMemory                   = false
 	DefaultCreateDefaultTarget          = true
 	DefaultDiscoveryAutoStart           = false
@@ -142,8 +142,8 @@ func init() {
 	engineCmd.Flags().String(APIKeyPasswordFlag, auth.DefaultApiKeyPassword, "Specifies the password used to proctect the API private key")
 	engineCmd.Flags().String(APIKeyPathFlag, auth.DefaultApiKeyPath, "Specifies the location of the API private key")
 	engineCmd.Flags().Bool(APIKeySaveOnCreateFlag, auth.DefaultApiKeySaveOnCreate, "Specifies whether the API key should be saved on creation. It will only created if the default location is used.")
-	engineCmd.Flags().Int16(APIgRPCPortFlag, DefaultAPIgRPCPort, "Specifies the port used for the gRPC API")
-	engineCmd.Flags().Int16(APIHTTPPortFlag, rest.DefaultAPIHTTPPort, "Specifies the port used for the HTTP API")
+	engineCmd.Flags().Uint16(APIgRPCPortFlag, DefaultAPIgRPCPort, "Specifies the port used for the gRPC API")
+	engineCmd.Flags().Uint16(APIHTTPPortFlag, rest.DefaultAPIHTTPPort, "Specifies the port used for the HTTP API")
 	engineCmd.Flags().String(APIJWKSURLFlag, service.DefaultJWKSURL, "Specifies the JWKS URL used to verify authentication tokens in the gRPC and HTTP API")
 	engineCmd.Flags().String(ServiceOAuth2EndpointFlag, DefaultServiceOAuth2Endpoint, "Specifies the OAuth 2.0 token endpoint")
 	engineCmd.Flags().String(ServiceOAuth2ClientIDFlag, DefaultServiceOAuth2ClientID, "Specifies the OAuth 2.0 client ID")
@@ -156,7 +156,7 @@ func init() {
 	engineCmd.Flags().String(DBPasswordFlag, DefaultDBPassword, "Provides password of database")
 	engineCmd.Flags().String(DBHostFlag, DefaultDBHost, "Provides address of database")
 	engineCmd.Flags().String(DBNameFlag, DefaultDBName, "Provides name of database")
-	engineCmd.Flags().Int16(DBPortFlag, DefaultDBPort, "Provides port for database")
+	engineCmd.Flags().Uint16(DBPortFlag, DefaultDBPort, "Provides port for database")
 	engineCmd.Flags().Bool(DBInMemoryFlag, DefaultDBInMemory, "Uses an in-memory database which is not persisted at all")
 	engineCmd.Flags().Bool(CreateDefaultTarget, DefaultCreateDefaultTarget, "Creates a default target cloud service if it does not exist")
 	engineCmd.Flags().Bool(DiscoveryAutoStartFlag, DefaultDiscoveryAutoStart, "Automatically start the discovery when engine starts")
@@ -218,7 +218,7 @@ func doCmd(_ *cobra.Command, _ []string) (err error) {
 	} else {
 		db, err = gorm.NewStorage(gorm.WithPostgres(
 			viper.GetString(DBHostFlag),
-			int16(viper.GetInt(DBPortFlag)),
+			uint16(viper.GetUint(DBPortFlag)),
 			viper.GetString(DBUserNameFlag),
 			viper.GetString(DBPasswordFlag),
 			viper.GetString(DBNameFlag),
@@ -278,8 +278,8 @@ func doCmd(_ *cobra.Command, _ []string) (err error) {
 		}
 	}
 
-	grpcPort := viper.GetInt(APIgRPCPortFlag)
-	httpPort := viper.GetInt(APIHTTPPortFlag)
+	grpcPort := uint16(viper.GetUint(APIgRPCPortFlag))
+	httpPort := uint16(viper.GetUint(APIHTTPPortFlag))
 
 	grpcLogger := logrus.New()
 	grpcLogger.Formatter = &formatter.GRPCFormatter{TextFormatter: logrus.TextFormatter{ForceColors: true}}

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -93,23 +93,23 @@ const (
 	DiscoveryProviderFlag            = "discovery-provider"
 	DashboardURLFlag                 = "dashboard-url"
 
-	DefaultAPIDefaultUser               = "clouditor"
-	DefaultAPIDefaultPassword           = "clouditor"
-	DefaultAPIgRPCPort                  = 9090
-	DefaultAPIStartEmbeddedOAuth2Server = true
-	DefaultServiceOAuth2Endpoint        = "http://localhost:8080/v1/auth/token"
-	DefaultServiceOAuth2ClientID        = "clouditor"
-	DefaultServiceOAuth2ClientSecret    = "clouditor"
-	DefaultDBUserName                   = "postgres"
-	DefaultDBPassword                   = "postgres"
-	DefaultDBHost                       = "localhost"
-	DefaultDBName                       = "postgres"
-	DefaultDBPort                       = 5432
-	DefaultDBSSLMode                    = "disable"
-	DefaultDBInMemory                   = false
-	DefaultCreateDefaultTarget          = true
-	DefaultDiscoveryAutoStart           = false
-	DefaultDashboardURL                 = "http://localhost:8080"
+	DefaultAPIDefaultUser                      = "clouditor"
+	DefaultAPIDefaultPassword                  = "clouditor"
+	DefaultAPIgRPCPort                  uint16 = 9090
+	DefaultAPIStartEmbeddedOAuth2Server        = true
+	DefaultServiceOAuth2Endpoint               = "http://localhost:8080/v1/auth/token"
+	DefaultServiceOAuth2ClientID               = "clouditor"
+	DefaultServiceOAuth2ClientSecret           = "clouditor"
+	DefaultDBUserName                          = "postgres"
+	DefaultDBPassword                          = "postgres"
+	DefaultDBHost                              = "localhost"
+	DefaultDBName                              = "postgres"
+	DefaultDBPort                       uint16 = 5432
+	DefaultDBSSLMode                           = "disable"
+	DefaultDBInMemory                          = false
+	DefaultCreateDefaultTarget                 = true
+	DefaultDiscoveryAutoStart                  = false
+	DefaultDashboardURL                        = "http://localhost:8080"
 
 	EnvPrefix = "CLOUDITOR"
 )

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -94,7 +94,7 @@ const (
 
 	DefaultAPIDefaultUser               = "clouditor"
 	DefaultAPIDefaultPassword           = "clouditor"
-	DefaultAPIgRPCPort                  = uint16(9090)
+	DefaultAPIgRPCPort                  = 9090
 	DefaultAPIStartEmbeddedOAuth2Server = true
 	DefaultServiceOAuth2Endpoint        = "http://localhost:8080/v1/auth/token"
 	DefaultServiceOAuth2ClientID        = "clouditor"
@@ -103,7 +103,7 @@ const (
 	DefaultDBPassword                   = "postgres"
 	DefaultDBHost                       = "localhost"
 	DefaultDBName                       = "postgres"
-	DefaultDBPort                       = uint16(5432)
+	DefaultDBPort                       = 5432
 	DefaultDBInMemory                   = false
 	DefaultCreateDefaultTarget          = true
 	DefaultDiscoveryAutoStart           = false

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -86,6 +86,7 @@ const (
 	DBHostFlag                       = "db-host"
 	DBNameFlag                       = "db-name"
 	DBPortFlag                       = "db-port"
+	DBSSLModeFlag                    = "db-ssl-mode"
 	DBInMemoryFlag                   = "db-in-memory"
 	CreateDefaultTarget              = "target-default-create"
 	DiscoveryAutoStartFlag           = "discovery-auto-start"
@@ -104,6 +105,7 @@ const (
 	DefaultDBHost                       = "localhost"
 	DefaultDBName                       = "postgres"
 	DefaultDBPort                       = 5432
+	DefaultDBSSLMode                    = "disable"
 	DefaultDBInMemory                   = false
 	DefaultCreateDefaultTarget          = true
 	DefaultDiscoveryAutoStart           = false
@@ -157,6 +159,7 @@ func init() {
 	engineCmd.Flags().String(DBHostFlag, DefaultDBHost, "Provides address of database")
 	engineCmd.Flags().String(DBNameFlag, DefaultDBName, "Provides name of database")
 	engineCmd.Flags().Uint16(DBPortFlag, DefaultDBPort, "Provides port for database")
+	engineCmd.Flags().String(DBSSLModeFlag, DefaultDBSSLMode, "The SSL mode for the database")
 	engineCmd.Flags().Bool(DBInMemoryFlag, DefaultDBInMemory, "Uses an in-memory database which is not persisted at all")
 	engineCmd.Flags().Bool(CreateDefaultTarget, DefaultCreateDefaultTarget, "Creates a default target cloud service if it does not exist")
 	engineCmd.Flags().Bool(DiscoveryAutoStartFlag, DefaultDiscoveryAutoStart, "Automatically start the discovery when engine starts")
@@ -183,6 +186,7 @@ func init() {
 	_ = viper.BindPFlag(DBHostFlag, engineCmd.Flags().Lookup(DBHostFlag))
 	_ = viper.BindPFlag(DBNameFlag, engineCmd.Flags().Lookup(DBNameFlag))
 	_ = viper.BindPFlag(DBPortFlag, engineCmd.Flags().Lookup(DBPortFlag))
+	_ = viper.BindPFlag(DBSSLModeFlag, engineCmd.Flags().Lookup(DBSSLModeFlag))
 	_ = viper.BindPFlag(DBInMemoryFlag, engineCmd.Flags().Lookup(DBInMemoryFlag))
 	_ = viper.BindPFlag(CreateDefaultTarget, engineCmd.Flags().Lookup(CreateDefaultTarget))
 	_ = viper.BindPFlag(DiscoveryAutoStartFlag, engineCmd.Flags().Lookup(DiscoveryAutoStartFlag))
@@ -222,6 +226,7 @@ func doCmd(_ *cobra.Command, _ []string) (err error) {
 			viper.GetString(DBUserNameFlag),
 			viper.GetString(DBPasswordFlag),
 			viper.GetString(DBNameFlag),
+			viper.GetString(DBSSLModeFlag),
 		))
 	}
 	if err != nil {

--- a/internal/testutil/auth.go
+++ b/internal/testutil/auth.go
@@ -45,7 +45,7 @@ func StartAuthenticationServer() (srv *oauth2.AuthorizationServer, port uint16, 
 		_ = srv.Serve(nl)
 	}()
 
-	port = uint16(nl.Addr().(*net.TCPAddr).Port)
+	port = nl.Addr().(*net.TCPAddr).AddrPort().Port()
 
 	return srv, port, nil
 }

--- a/internal/testutil/auth.go
+++ b/internal/testutil/auth.go
@@ -20,7 +20,7 @@ const (
 
 // StartAuthenticationServer starts an authentication server on a random port with
 // users and clients specified in the TestAuthUser and TestAuthClientID constants.
-func StartAuthenticationServer() (srv *oauth2.AuthorizationServer, port int, err error) {
+func StartAuthenticationServer() (srv *oauth2.AuthorizationServer, port uint16, err error) {
 	var nl net.Listener
 
 	srv = oauth2.NewServer(":0",
@@ -45,24 +45,24 @@ func StartAuthenticationServer() (srv *oauth2.AuthorizationServer, port int, err
 		_ = srv.Serve(nl)
 	}()
 
-	port = nl.Addr().(*net.TCPAddr).Port
+	port = uint16(nl.Addr().(*net.TCPAddr).Port)
 
 	return srv, port, nil
 }
 
-func JWKSURL(port int) string {
+func JWKSURL(port uint16) string {
 	return fmt.Sprintf("http://localhost:%d/.well-known/jwks.json", port)
 }
 
-func TokenURL(port int) string {
+func TokenURL(port uint16) string {
 	return fmt.Sprintf("http://localhost:%d/v1/auth/token", port)
 }
 
-func AuthURL(port int) string {
+func AuthURL(port uint16) string {
 	return fmt.Sprintf("http://localhost:%d/v1/auth/authorize", port)
 }
 
-func AuthClientConfig(port int) *clientcredentials.Config {
+func AuthClientConfig(port uint16) *clientcredentials.Config {
 	return &clientcredentials.Config{
 		ClientID:     TestAuthClientID,
 		ClientSecret: TestAuthClientSecret,

--- a/internal/testutil/clitest/cli.go
+++ b/internal/testutil/clitest/cli.go
@@ -22,7 +22,7 @@ import (
 // test credentials. It is the responsibility of the caller to cleanup the temporary directory.
 //
 // This function will use asserts and fail/panic if errors occurs.
-func PrepareSession(authPort int, authSrv *oauth2.AuthorizationServer, grpcURL string) (dir string, err error) {
+func PrepareSession(authPort uint16, authSrv *oauth2.AuthorizationServer, grpcURL string) (dir string, err error) {
 	var (
 		token   *oauth2.Token
 		session *cli.Session
@@ -79,8 +79,8 @@ func RunCLITest(m *testing.M, opts ...service.StartGRPCServerOption) (code int) 
 		err      error
 		tmpDir   string
 		auth     *oauth2.AuthorizationServer
-		authPort int
-		grpcPort int
+		authPort uint16
+		grpcPort uint16
 		sock     net.Listener
 		server   *grpc.Server
 	)
@@ -95,7 +95,7 @@ func RunCLITest(m *testing.M, opts ...service.StartGRPCServerOption) (code int) 
 		panic(err)
 	}
 
-	grpcPort = sock.Addr().(*net.TCPAddr).Port
+	grpcPort = sock.Addr().(*net.TCPAddr).AddrPort().Port()
 
 	tmpDir, err = PrepareSession(authPort, auth, fmt.Sprintf("localhost:%d", grpcPort))
 	if err != nil {

--- a/persistence/gorm/gorm.go
+++ b/persistence/gorm/gorm.go
@@ -91,9 +91,9 @@ func WithMaxOpenConns(max int) StorageOption {
 }
 
 // WithPostgres is an option to configure Storage to use a Postgres DB
-func WithPostgres(host string, port uint16, user string, pw string, db string) StorageOption {
+func WithPostgres(host string, port uint16, user string, pw string, db string, sslmode string) StorageOption {
 	return func(s *storage) {
-		s.dialector = postgres.Open(fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", user, pw, host, port, db))
+		s.dialector = postgres.Open(fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s", user, pw, host, port, db, sslmode))
 	}
 }
 

--- a/persistence/gorm/gorm.go
+++ b/persistence/gorm/gorm.go
@@ -91,7 +91,7 @@ func WithMaxOpenConns(max int) StorageOption {
 }
 
 // WithPostgres is an option to configure Storage to use a Postgres DB
-func WithPostgres(host string, port int16, user string, pw string, db string) StorageOption {
+func WithPostgres(host string, port uint16, user string, pw string, db string) StorageOption {
 	return func(s *storage) {
 		s.dialector = postgres.Open(fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", user, pw, host, port, db))
 	}

--- a/persistence/gorm/gorm_test.go
+++ b/persistence/gorm/gorm_test.go
@@ -47,7 +47,7 @@ func TestStorageOptions(t *testing.T) {
 			name: "postgres with option - invalid port",
 			args: args{
 				opts: []StorageOption{
-					WithPostgres("", 0, "", "", ""),
+					WithPostgres("", 0, "", "", "", ""),
 				},
 			},
 			wantDialectorType: "",

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -93,7 +93,7 @@ var (
 	DefaultAllowedMethods = []string{"GET", "POST", "PUT", "DELETE"}
 
 	// DefaultAPIHTTPPort specifies the default port for the REST API.
-	DefaultAPIHTTPPort int16 = 8080
+	DefaultAPIHTTPPort uint16 = 8080
 )
 
 func init() {
@@ -168,7 +168,7 @@ func WithEmbeddedOAuth2Server(keyPath string, keyPassword string, saveOnCreate b
 
 // RunServer starts our REST API. The REST API is a reverse proxy using grpc-gateway that
 // exposes certain gRPC calls as RESTful HTTP methods.
-func RunServer(ctx context.Context, grpcPort int, httpPort int, serverOpts ...ServerConfigOption) (err error) {
+func RunServer(ctx context.Context, grpcPort uint16, httpPort uint16, serverOpts ...ServerConfigOption) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -249,7 +249,7 @@ func GetReadyChannel() chan bool {
 }
 
 // GetServerPort returns the actual port used by the REST API
-func GetServerPort() (int, error) {
+func GetServerPort() (uint16, error) {
 	if sock == nil {
 		return 0, errors.New("server socket is empty")
 	}
@@ -260,7 +260,7 @@ func GetServerPort() (int, error) {
 		return 0, errors.New("server socket address is not a TCP address")
 	}
 
-	return tcpAddr.Port, nil
+	return tcpAddr.AddrPort().Port(), nil
 }
 
 // handleCORS adds an appropriate http.HandlerFunc to an existing http.Handler to configure

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 		err      error
 		server   *grpc.Server
 		sock     net.Listener
-		authPort int
+		authPort uint16
 	)
 
 	clitest.AutoChdir()
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	grpcPort = uint16(sock.Addr().(*net.TCPAddr).Port)
+	grpcPort = sock.Addr().(*net.TCPAddr).AddrPort().Port()
 
 	exit := m.Run()
 

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -52,7 +52,7 @@ var (
 	methods = []string{"GET", "POST"}
 	headers = DefaultAllowedHeaders
 
-	grpcPort = uint16(0)
+	grpcPort uint16 = 0
 )
 
 func TestMain(m *testing.M) {

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -52,7 +52,7 @@ var (
 	methods = []string{"GET", "POST"}
 	headers = DefaultAllowedHeaders
 
-	grpcPort = 0
+	grpcPort = uint16(0)
 )
 
 func TestMain(m *testing.M) {
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	grpcPort = sock.Addr().(*net.TCPAddr).Port
+	grpcPort = uint16(sock.Addr().(*net.TCPAddr).Port)
 
 	exit := m.Run()
 

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -56,7 +56,7 @@ import (
 )
 
 var (
-	authPort int
+	authPort uint16
 )
 
 func TestMain(m *testing.M) {

--- a/service/assessment/benchmark_test.go
+++ b/service/assessment/benchmark_test.go
@@ -27,6 +27,7 @@ func createEvidences(n int, m int, b *testing.B) int {
 		wg   sync.WaitGroup
 		err  error
 		sock net.Listener
+		port uint16
 	)
 
 	logrus.SetLevel(logrus.PanicLevel)
@@ -56,7 +57,9 @@ func createEvidences(n int, m int, b *testing.B) int {
 
 	var count int64 = 0
 
-	addr := fmt.Sprintf("localhost:%d", sock.Addr().(*net.TCPAddr).Port)
+	port = sock.Addr().(*net.TCPAddr).AddrPort().Port()
+
+	addr := fmt.Sprintf("localhost:%d", port)
 
 	svc := NewService(WithOrchestratorAddress(addr), WithEvidenceStoreAddress(addr))
 

--- a/service/auth_middleware_test.go
+++ b/service/auth_middleware_test.go
@@ -64,7 +64,7 @@ func TestAuthConfig_AuthFunc(t *testing.T) {
 	var (
 		authSrv *oauth2.AuthorizationServer
 		err     error
-		port    int
+		port    uint16
 	)
 
 	// We need to start a REST server for JWKS (using our auth server)

--- a/service/discovery/azure/arm_template.go
+++ b/service/discovery/azure/arm_template.go
@@ -398,7 +398,7 @@ func (d *azureARMTemplateDiscovery) handleLoadBalancer(template map[string]inter
 			},
 			Compute: []voc.ResourceID{},
 			Ips:     []string{},
-			Ports:   []int16{}, // TODO: This should be an uint16!
+			Ports:   []uint16{},
 		},
 		AccessRestrictions: &[]voc.AccessRestriction{
 			// TODO(all)

--- a/service/discovery/azure/arm_template.go
+++ b/service/discovery/azure/arm_template.go
@@ -398,7 +398,7 @@ func (d *azureARMTemplateDiscovery) handleLoadBalancer(template map[string]inter
 			},
 			Compute: []voc.ResourceID{},
 			Ips:     []string{},
-			Ports:   []int16{},
+			Ports:   []int16{}, // TODO: This should be an uint16!
 		},
 		AccessRestrictions: &[]voc.AccessRestriction{
 			// TODO(all)

--- a/service/discovery/azure/network.go
+++ b/service/discovery/azure/network.go
@@ -148,7 +148,7 @@ func (d *azureNetworkDiscovery) handleLoadBalancer(lb *network.LoadBalancer) voc
 				},
 			},
 			Ips:   d.publicIPAddressFromLoadBalancer(lb),
-			Ports: LoadBalancerPorts(lb),
+			Ports: loadBalancerPorts(lb),
 		},
 		// TODO(all): do we need the AccessRestriction for load balancers?
 		AccessRestrictions: &[]voc.AccessRestriction{},
@@ -177,10 +177,9 @@ func (*azureNetworkDiscovery) handleNetworkInterfaces(ni *network.Interface) voc
 	}
 }
 
-func LoadBalancerPorts(lb *network.LoadBalancer) (loadBalancerPorts []int16) {
-
+func loadBalancerPorts(lb *network.LoadBalancer) (loadBalancerPorts []uint16) {
 	for _, item := range *lb.LoadBalancingRules {
-		loadBalancerPorts = append(loadBalancerPorts, int16(to.Int32(item.FrontendPort)))
+		loadBalancerPorts = append(loadBalancerPorts, uint16(to.Int32(item.FrontendPort)))
 	}
 
 	return loadBalancerPorts

--- a/service/discovery/azure/network_test.go
+++ b/service/discovery/azure/network_test.go
@@ -218,7 +218,7 @@ func TestNetwork(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.Equal(t, "lb1", lb.Name)
-	assert.Equal(t, int16(1234), lb.Ports[0])
+	assert.Equal(t, uint16(1234), lb.Ports[0])
 	assert.Equal(t, "111.222.333.444", lb.Ips[0])
 
 	lb, ok = list[2].(*voc.LoadBalancer)

--- a/service/discovery/k8s/network.go
+++ b/service/discovery/k8s/network.go
@@ -85,10 +85,10 @@ func (d k8sNetworkDiscovery) List() ([]voc.IsCloudResource, error) {
 }
 
 func (k8sNetworkDiscovery) handleService(service *corev1.Service) voc.IsNetwork {
-	var ports []int16
+	var ports []uint16
 
 	for _, v := range service.Spec.Ports {
-		ports = append(ports, int16(v.Port))
+		ports = append(ports, uint16(v.Port))
 	}
 
 	return &voc.NetworkService{
@@ -128,7 +128,7 @@ func (k8sNetworkDiscovery) handleIngress(ingress *v1.Ingress) voc.IsNetwork {
 				},
 			},
 			Ips:   nil, // TODO (oxisto): fill out IPs
-			Ports: []int16{80, 443},
+			Ports: []uint16{80, 443},
 		},
 		// TODO(oxisto): fill out access restrictions
 		AccessRestrictions: &[]voc.AccessRestriction{},

--- a/service/discovery/k8s/network_test.go
+++ b/service/discovery/k8s/network_test.go
@@ -98,7 +98,7 @@ func TestListIngresses(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "my-service", service.Name)
 	assert.Equal(t, "/namespaces/my-namespace/services/my-service", string(service.ID))
-	assert.Equal(t, []int16{80}, service.Ports)
+	assert.Equal(t, []uint16{80}, service.Ports)
 	assert.Equal(t, []string{"127.0.0.1"}, service.Ips)
 
 	lb, ok := list[1].(*voc.LoadBalancer)

--- a/voc/automatic_updates.go
+++ b/voc/automatic_updates.go
@@ -30,6 +30,6 @@ import "time"
 type AutomaticUpdates struct {
 	*Integrity
 	Enabled      bool          `json:"enabled"`
-	SecurityOnly bool          `json:"securityOnly"`
 	Interval     time.Duration `json:"interval"`
+	SecurityOnly bool          `json:"securityOnly"`
 }

--- a/voc/backup.go
+++ b/voc/backup.go
@@ -29,7 +29,7 @@ import "time"
 
 type Backup struct {
 	*Availability
-	RetentionPeriod time.Duration `json:"retentionPeriod"`
 	Enabled         bool          `json:"enabled"`
+	RetentionPeriod time.Duration `json:"retentionPeriod"`
 	Policy          string        `json:"policy"`
 }

--- a/voc/network_service.go
+++ b/voc/network_service.go
@@ -30,5 +30,5 @@ type NetworkService struct {
 	Compute             []ResourceID         `json:"compute"`
 	TransportEncryption *TransportEncryption `json:"transportEncryption"`
 	Ips                 []string             `json:"ips"`
-	Ports               []int16              `json:"ports"`
+	Ports               []int16              `json:"ports"` // TODO(oxisto): This should be an uint16
 }

--- a/voc/network_service.go
+++ b/voc/network_service.go
@@ -30,5 +30,5 @@ type NetworkService struct {
 	Compute             []ResourceID         `json:"compute"`
 	TransportEncryption *TransportEncryption `json:"transportEncryption"`
 	Ips                 []string             `json:"ips"`
-	Ports               []int16              `json:"ports"` // TODO(oxisto): This should be an uint16
+	Ports               []uint16             `json:"ports"`
 }


### PR DESCRIPTION
Some code was incorrectly using `int16` for ports (which truncates) it or `int` (which is ok but unncessary). This PR addresses most of it. 

This also includes a small ontology update from https://github.com/clouditor/cloud-property-graph/pull/45