### PR TITLE
Update description for GetControl()

### DIFF
--- a/api/orchestrator/orchestrator.proto
+++ b/api/orchestrator/orchestrator.proto
@@ -334,7 +334,7 @@ service Orchestrator {
 
   // Retrieves a control specified by the catalog ID, the control's category
   // name and the control ID. If present, it also includes a list of
-  // sub-controls.
+  // sub-controls if present or a list of metrics if no sub-controls but metrics are present.
   rpc GetControl(GetControlRequest) returns (Control) {
     option (google.api.http) = {
       get : "/v1/orchestrator/catalogs/{catalog_id}/categories/{category_name}/"

--- a/api/orchestrator/orchestrator.proto
+++ b/api/orchestrator/orchestrator.proto
@@ -334,7 +334,7 @@ service Orchestrator {
 
   // Retrieves a control specified by the catalog ID, the control's category
   // name and the control ID. If present, it also includes a list of
-  // sub-controls and any metrics associated to the control.
+  // sub-controls.
   rpc GetControl(GetControlRequest) returns (Control) {
     option (google.api.http) = {
       get : "/v1/orchestrator/catalogs/{catalog_id}/categories/{category_name}/"

--- a/api/orchestrator/orchestrator_grpc.pb.go
+++ b/api/orchestrator/orchestrator_grpc.pb.go
@@ -107,7 +107,7 @@ type OrchestratorClient interface {
 	ListControls(ctx context.Context, in *ListControlsRequest, opts ...grpc.CallOption) (*ListControlsResponse, error)
 	// Retrieves a control specified by the catalog ID, the control's category
 	// name and the control ID. If present, it also includes a list of
-	// sub-controls and any metrics associated to the control.
+	// sub-controls if present or a list of metrics if no sub-controls but metrics are present.
 	GetControl(ctx context.Context, in *GetControlRequest, opts ...grpc.CallOption) (*Control, error)
 	// Creates a new Target of Evaluation
 	CreateTargetOfEvaluation(ctx context.Context, in *CreateTargetOfEvaluationRequest, opts ...grpc.CallOption) (*TargetOfEvaluation, error)
@@ -630,7 +630,7 @@ type OrchestratorServer interface {
 	ListControls(context.Context, *ListControlsRequest) (*ListControlsResponse, error)
 	// Retrieves a control specified by the catalog ID, the control's category
 	// name and the control ID. If present, it also includes a list of
-	// sub-controls and any metrics associated to the control.
+	// sub-controls if present or a list of metrics if no sub-controls but metrics are present.
 	GetControl(context.Context, *GetControlRequest) (*Control, error)
 	// Creates a new Target of Evaluation
 	CreateTargetOfEvaluation(context.Context, *CreateTargetOfEvaluationRequest) (*TargetOfEvaluation, error)

--- a/openapi/orchestrator/openapi.yaml
+++ b/openapi/orchestrator/openapi.yaml
@@ -366,7 +366,7 @@ paths:
             description: |-
                 Retrieves a control specified by the catalog ID, the control's category
                  name and the control ID. If present, it also includes a list of
-                 sub-controls and any metrics associated to the control.
+                 sub-controls if present or a list of metrics if no sub-controls but metrics are present.
             operationId: Orchestrator_GetControl
             parameters:
                 - name: catalogId


### PR DESCRIPTION
The description is not correct. Only if one hierarchy level exists for the control the metrics are returned. In case of two hierarchy levels for controls (e.g., control OPS-13 and subcontrols OPS-13.1, OPS-13.2, OPS-13.3) only the control OPS-13 with its subcontrols OPS-13.1, OPS-13.2, OPS-13.3 is returned .