### PR TITLE
Fix `PermissionDenied` for `listAssessmentResults` in case of `AuthorizationStrategyAllowAll`

### DIFF
--- a/service/authz.go
+++ b/service/authz.go
@@ -28,14 +28,13 @@ package service
 import (
 	"context"
 
+	"github.com/golang-jwt/jwt/v4"
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"clouditor.io/clouditor/api/orchestrator"
-
-	"github.com/golang-jwt/jwt/v4"
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 )
 
 // RequestType specifies the type of request, usually CRUD.

--- a/service/authz.go
+++ b/service/authz.go
@@ -28,10 +28,11 @@ package service
 import (
 	"context"
 
-	"clouditor.io/clouditor/api/orchestrator"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"clouditor.io/clouditor/api/orchestrator"
 
 	"github.com/golang-jwt/jwt/v4"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
@@ -122,12 +123,14 @@ func (a *AuthorizationStrategyJWT) AllowedCloudServices(ctx context.Context) (al
 // AuthorizationStrategyAllowAll is an AuthorizationStrategy that allows all requests.
 type AuthorizationStrategyAllowAll struct{}
 
-// CheckAccess checks whether the current request can be fulfilled using the current access strategy.
+// CheckAccess checks whether the current request can be fulfilled using the current access strategy. Returns true since
+// strategy is `AuthorizationStrategyAllowAll`
 func (*AuthorizationStrategyAllowAll) CheckAccess(_ context.Context, _ RequestType, _ orchestrator.CloudServiceRequest) bool {
 	return true
 }
 
-// AllowedCloudServices retrieves a list of allowed cloud service IDs according to the current access strategy.
+// AllowedCloudServices retrieves a list of allowed cloud service IDs according to the current access strategy. Returns
+// `all = true` since strategy is `AuthorizationStrategyAllowAll`
 func (*AuthorizationStrategyAllowAll) AllowedCloudServices(_ context.Context) (all bool, list []string) {
 	return true, nil
 }

--- a/service/orchestrator/assessment_results.go
+++ b/service/orchestrator/assessment_results.go
@@ -45,11 +45,15 @@ func (svc *Service) ListAssessmentResults(ctx context.Context, req *assessment.L
 	var all bool
 
 	// Check, if the current filter is valid according to the authorization strategy. Omitting the cloud service ID is
-	// only allowed, if one can access all the cloud services. Furthermore, the content of the filtered cloud service ID
-	// must be in the list of allowed cloud service IDs.
+	// only allowed, if one can access *all* the cloud services.
 	all, allowed = svc.authz.AllowedCloudServices(ctx)
-	if !all && (req.FilteredCloudServiceId == "" ||
-		(req.FilteredCloudServiceId != "" && !slices.Contains(allowed, req.FilteredCloudServiceId))) {
+	if !all && req.FilteredCloudServiceId == "" {
+		return nil, service.ErrPermissionDenied
+	}
+
+	// Furthermore, the content of the filtered cloud service ID must be in the list of allowed cloud service IDs,
+	// unless one can access *all* the cloud services.
+	if !all && req.FilteredCloudServiceId != "" && !slices.Contains(allowed, req.FilteredCloudServiceId) {
 		return nil, service.ErrPermissionDenied
 	}
 

--- a/service/orchestrator/assessment_results.go
+++ b/service/orchestrator/assessment_results.go
@@ -28,12 +28,13 @@ package orchestrator
 import (
 	"context"
 
-	"clouditor.io/clouditor/api/assessment"
-	"clouditor.io/clouditor/service"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"clouditor.io/clouditor/api/assessment"
+	"clouditor.io/clouditor/service"
 )
 
 // ListAssessmentResults is a method implementation of the orchestrator interface
@@ -47,8 +48,8 @@ func (svc *Service) ListAssessmentResults(ctx context.Context, req *assessment.L
 	// only allowed, if one can access all the cloud services. Furthermore, the content of the filtered cloud service ID
 	// must be in the list of allowed cloud service IDs.
 	all, allowed = svc.authz.AllowedCloudServices(ctx)
-	if (req.FilteredCloudServiceId == "" && !all) ||
-		(req.FilteredCloudServiceId != "" && !slices.Contains(allowed, req.FilteredCloudServiceId)) {
+	if !all && (req.FilteredCloudServiceId == "" ||
+		(req.FilteredCloudServiceId != "" && !slices.Contains(allowed, req.FilteredCloudServiceId))) {
 		return nil, service.ErrPermissionDenied
 	}
 

--- a/service/orchestrator/assessment_results_test.go
+++ b/service/orchestrator/assessment_results_test.go
@@ -92,6 +92,48 @@ func TestService_ListAssessmentResults(t *testing.T) {
 				return assert.Equal(t, err, service.ErrPermissionDenied)
 			},
 		},
+		{
+			name: "specify filtered cloud service ID which is not allowed",
+			fields: fields{
+				results: map[string]*assessment.AssessmentResult{
+					"1": {Id: "1", Timestamp: timestamppb.New(time.Unix(1, 0)), CloudServiceId: testutil.TestCloudService1},
+					"2": {Id: "2", Timestamp: timestamppb.New(time.Unix(0, 0)), CloudServiceId: testutil.TestCloudService2},
+				},
+				authz: &service.AuthorizationStrategyJWT{Key: testutil.TestCustomClaims},
+			},
+			args: args{
+				ctx: testutil.TestContextOnlyService1,
+				req: &assessment.ListAssessmentResultsRequest{
+					FilteredCloudServiceId: testutil.TestCloudService2,
+				},
+			},
+			wantRes: nil,
+			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Equal(t, err, service.ErrPermissionDenied)
+			},
+		},
+		{
+			name: "return filtered cloud service ID",
+			fields: fields{
+				results: map[string]*assessment.AssessmentResult{
+					"1": {Id: "1", Timestamp: timestamppb.New(time.Unix(1, 0)), CloudServiceId: testutil.TestCloudService1},
+					"2": {Id: "2", Timestamp: timestamppb.New(time.Unix(0, 0)), CloudServiceId: testutil.TestCloudService2},
+				},
+				authz: &service.AuthorizationStrategyJWT{Key: testutil.TestCustomClaims},
+			},
+			args: args{
+				ctx: testutil.TestContextOnlyService1,
+				req: &assessment.ListAssessmentResultsRequest{
+					FilteredCloudServiceId: testutil.TestCloudService1,
+				},
+			},
+			wantRes: &assessment.ListAssessmentResultsResponse{
+				Results: []*assessment.AssessmentResult{
+					{Id: "1", Timestamp: timestamppb.New(time.Unix(1, 0)), CloudServiceId: testutil.TestCloudService1},
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #873.
In  `all, allowed = svc.authz.AllowedCloudServices(ctx)`, `all` is true and the list`allowed` nil if the strategy is `AuthorizationStrategyAllowAll`. And if `all` is true, the list shouldn't be checked. I adjusted the if condition accordingly and changed a bit the comments of `AuthorizationStrategyAllowAll` interface methods.