### PR TITLE
Refactor StoreAssessmentResult response

### DIFF
--- a/service/orchestrator/orchestrator.go
+++ b/service/orchestrator/orchestrator.go
@@ -211,8 +211,6 @@ func (s *Service) StoreAssessmentResult(_ context.Context, req *orchestrator.Sto
 	err = service.ValidateRequest(req)
 	if err != nil {
 		log.Error(err)
-		go s.informHook(nil, err)
-
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 

--- a/service/orchestrator/orchestrator.go
+++ b/service/orchestrator/orchestrator.go
@@ -246,12 +246,16 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 		storeAssessmentResultReq := &orchestrator.StoreAssessmentResultRequest{
 			Result: result.Result,
 		}
-		res, err = s.StoreAssessmentResult(context.Background(), storeAssessmentResultReq)
+		_, err = s.StoreAssessmentResult(context.Background(), storeAssessmentResultReq)
 		if err != nil {
 			// Create response message. The StoreAssessmentResult method does not need that message, so we have to create it here for the stream response.
 			res = &orchestrator.StoreAssessmentResultResponse{
 				Status:        false,
 				StatusMessage: err.Error(),
+			}
+		} else {
+			res = &orchestrator.StoreAssessmentResultResponse{
+				Status: true,
 			}
 		}
 


### PR DESCRIPTION
Based on the nested methods StoreAssessmentResult and StoreAssessmentResults the response message is not correct for the StoreAssessmentResult method. We have to create the response message only in the StoreAssessmentResults method because we use a gRPC response stream there. If no gRPC response stream is used, only an error message is returned.