### PR TITLE
Re-starting old stream channels instead of re-creating them

### DIFF
--- a/api/streams.go
+++ b/api/streams.go
@@ -60,6 +60,9 @@ type StreamChannelOf[StreamType grpc.ClientStream, MsgType proto.Message] struct
 
 	// component name
 	component string
+
+	// dead specifies that this channel lost connection and needs to be re-started
+	dead bool
 }
 
 // InitFuncOf describes a function with type parameters that creates any kind of stream towards a gRPC server specified
@@ -127,6 +130,12 @@ func (s *StreamsOf[StreamType, MsgType]) GetStream(target string, component stri
 		if err != nil {
 			return nil, fmt.Errorf("could not add stream for %s with target '%s': %w", component, target, err)
 		}
+	} else if c.dead {
+		// We could have a dead stream that we need to restart. in this case, we can recycle a few things, e.g. the channel
+		c, err = s.restartStream(c, init, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("could not restart stream for %s with target '%s': %w", c.component, c.target, err)
+		}
 	}
 
 	return c, nil
@@ -169,28 +178,53 @@ func (s *StreamsOf[StreamType, MsgType]) addStream(target string, component stri
 	return c, nil
 }
 
-// removeStream deletes the channel from the stream map.
-func (s *StreamsOf[StreamType, MsgType]) removeStream(target string) {
-	s.log.Debugf("Removing stream channel for target %s", target)
+// restartStream restarts a stream to the given component and starts a goroutine for sending messages from the channel to the given component
+func (s *StreamsOf[StreamType, MsgType]) restartStream(c *StreamChannelOf[StreamType, MsgType], init InitFuncOf[StreamType], opts ...grpc.DialOption) (*StreamChannelOf[StreamType, MsgType], error) {
+	var err error
 
-	s.mutex.Lock()
-	delete(s.channels, target)
-	s.mutex.Unlock()
+	// We need an init func
+	if init == nil {
+		return nil, ErrMissingInitFunc
+	}
+
+	// Initialize the stream using our init function
+	c.stream, err = init(c.target, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("could not init stream: %w", err)
+	}
+
+	// Revive the stream
+	c.dead = false
+
+	s.log.Infof("Re-Established stream to %s (%s)", c.component, c.target)
+
+	// Start go routine for receiving messages from the stream (especially relevant for bi-directional streams).
+	go c.recvLoop(s)
+
+	// Start go routine for sending messages from the channel to the stream
+	go c.sendLoop(s)
+
+	return c, nil
 }
 
 // sendLoop continuously fetches new messages from the channel inside c and sends them to the appropriate stream.
 func (c *StreamChannelOf[StreamType, MsgType]) sendLoop(s *StreamsOf[StreamType, MsgType]) {
 	var err error
 
-	// Fetch new messages from channel (this will block)
+	// Fetch new (or queued old) messages from the channel. This will block.
 	for m := range c.channel {
 		// Try to send the message in our stream
 		err = c.stream.SendMsg(m)
 		if errors.Is(err, io.EOF) {
 			s.log.Infof("Stream to %s (%s) closed with EOF", c.component, c.target)
 
-			// Remove the stream from our map and end this goroutine
-			s.removeStream(c.target)
+			// Declare the stream as dead
+			c.dead = true
+
+			// Put the message back on the channel, so that it does not get lost
+			go func() {
+				c.channel <- m
+			}()
 			return
 		}
 
@@ -201,8 +235,13 @@ func (c *StreamChannelOf[StreamType, MsgType]) sendLoop(s *StreamsOf[StreamType,
 			// Close the stream gracefully. We can ignore any error resulting from the close here
 			_ = c.stream.CloseSend()
 
-			// Remove the stream from our map and end this goroutine
-			s.removeStream(c.target)
+			// Declare the stream as dead
+			c.dead = true
+
+			// Put the message back on the channel, so that it does not get lost
+			go func() {
+				c.channel <- m
+			}()
 			return
 		}
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 	"testing"
 
+	"clouditor.io/clouditor/api/assessment"
+	"clouditor.io/clouditor/api/evidence"
 	"clouditor.io/clouditor/api/orchestrator"
 	"clouditor.io/clouditor/internal/api"
 	"clouditor.io/clouditor/internal/testdata"
@@ -169,6 +171,16 @@ func TestLogRequest(t *testing.T) {
 				params: []string{fmt.Sprintf("and Catalog '%s'", testdata.MockCatalogID)},
 			},
 			want: "level=debug msg=TargetOfEvaluation updated for Cloud Service '11111111-1111-1111-1111-111111111111' and Catalog 'Cat1234'.\n",
+		},
+		{
+			name: "Send Evidence to queue",
+			args: args{
+				level:   logrus.DebugLevel,
+				reqType: Store,
+				req:     &assessment.AssessEvidenceRequest{Evidence: &evidence.Evidence{Id: testdata.MockEvidenceID}},
+				params:  []string{fmt.Sprintf("back into queue for %s (%s)", "orchestrator", "localhost")},
+			},
+			want: "level=debug msg=Evidence with ID '11111111-1111-1111-1111-111111111111' stored back into queue for orchestrator (localhost).\n",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds the behaviour of the `StreamsOf` when a channel is broken (e.g. through EOF). Previously, the stream channel was removed and completly created anew. However, this also meant that certain messages that were present at the time of breakage were lost. This PR changes this by putting the message back into the send-queue and recycling the send-queue in the new stream channel.
