### PR TITLE
Adding nil check for  context to `AllowedCloudServices` of `AuthorizationStrategyJWT`

### DIFF
--- a/service/authz.go
+++ b/service/authz.go
@@ -93,6 +93,12 @@ func (a *AuthorizationStrategyJWT) AllowedCloudServices(ctx context.Context) (al
 		s      string
 	)
 
+	// Check, if the context is nil
+	if ctx == nil {
+		log.Debugf("Retrieving allowed cloud services failed because of an empty context")
+		return false, nil
+	}
+
 	// Retrieve the raw token from the context
 	token, err = grpc_auth.AuthFromMD(ctx, "bearer")
 	if err != nil {

--- a/service/authz_test.go
+++ b/service/authz_test.go
@@ -286,6 +286,13 @@ func TestAuthorizationStrategyJWT_AllowedCloudServices(t *testing.T) {
 			wantAll:  false,
 			wantList: nil,
 		},
+		{
+			name:     "nil context",
+			fields:   fields{},
+			args:     args{ctx: nil},
+			wantAll:  false,
+			wantList: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The JWT authorization strategy was missing a nil check.