### PR TITLE
Exclude engine/main from codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - "**/*.pb.go" # ignore protoc generated files
   - "**/*.pb.*.go" # ignore protoc-gen-* generated files
+  - "cmd/engine/engine.go" # ignore main
 coverage:
   range: "70...85"
   status:


### PR DESCRIPTION
To avoid failing codecov checks when modifying engine.go