### PR TITLE
New `RPCConnection` type to bundle all gRPC connection related information

### DIFF
--- a/api/authorizer.go
+++ b/api/authorizer.go
@@ -130,13 +130,13 @@ func DefaultGrpcDialOptions(hostport string, s UsesAuthorizer, additionalOpts ..
 	// if the server-side has not enabled the auth middleware (for example in testing), it is perfectly
 	// fine to at least attempt to run it without one. If the server-side has enabled auth middleware
 	// and does not receive any client credentials, the actual RPC call will then fail later.
-	authorizer := s.Authorizer()
-
-	if authorizer != nil {
-		opts = append(opts, grpc.WithPerRPCCredentials(authorizer))
+	if s != nil {
+		if authorizer := s.Authorizer(); authorizer != nil {
+			opts = append(opts, grpc.WithPerRPCCredentials(authorizer))
+		}
 	}
 
-	// Appply any additional options that we might have
+	// Apply any additional options that we might have
 	opts = append(opts, additionalOpts...)
 
 	return opts

--- a/api/connection.go
+++ b/api/connection.go
@@ -1,0 +1,151 @@
+// Copyright 2023 Fraunhofer AISEC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//           $$\                           $$\ $$\   $$\
+//           $$ |                          $$ |\__|  $$ |
+//  $$$$$$$\ $$ | $$$$$$\  $$\   $$\  $$$$$$$ |$$\ $$$$$$\    $$$$$$\   $$$$$$\
+// $$  _____|$$ |$$  __$$\ $$ |  $$ |$$  __$$ |$$ |\_$$  _|  $$  __$$\ $$  __$$\
+// $$ /      $$ |$$ /  $$ |$$ |  $$ |$$ /  $$ |$$ |  $$ |    $$ /  $$ |$$ | \__|
+// $$ |      $$ |$$ |  $$ |$$ |  $$ |$$ |  $$ |$$ |  $$ |$$\ $$ |  $$ |$$ |
+// \$$$$$$\  $$ |\$$$$$   |\$$$$$   |\$$$$$$  |$$ |  \$$$   |\$$$$$   |$$ |
+//  \_______|\__| \______/  \______/  \_______|\__|   \____/  \______/ \__|
+//
+// This file is part of Clouditor Community Edition.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	sync "sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// RPCConnection is a helper function that wraps all necessary information for a gRPC connection, which is established
+// using [grpc.Dial]. It features transparent goroutine-safe lazy initialization of the connection by overloading the
+// underlying [grpc.ClientConn]. The connection is established automatically once the first client call is made. If an
+// [io.EOF] error is received the connection is tried to be re-established on the next client call.
+type RPCConnection[T any] struct {
+	// Target contains the target used in grpc.Dial. Ideally, this should not be changed after the first client call.
+	Target string
+
+	// Opts contain options used in grpc.Dial. Ideally, this should not be changed after the first client call.
+	Opts []grpc.DialOption
+
+	// Client contains a gRPC client that is used to issue the actual RPCs.
+	Client T
+
+	// authorizer is the authorizer used in grpc.Dual. Ideally, this should not be changed after the first client call.
+	authorizer Authorizer
+	// ClientConn is an embedded grpc.ClientConn that we hook to automatically establish the connection.
+	cc *grpc.ClientConn
+	// m is a mutex that synchronizes access to the client conn.
+	m sync.RWMutex
+}
+
+// SetAuthorizer implements UsesAuthorizer
+func (conn *RPCConnection[T]) SetAuthorizer(auth Authorizer) {
+	conn.authorizer = auth
+}
+
+// Authorizer implements UsesAuthorizer
+func (conn *RPCConnection[T]) Authorizer() Authorizer {
+	return conn.authorizer
+}
+
+// NewRPCConnection creates a new [RPCConnection] to the target using the specified function that creates a new client.
+func NewRPCConnection[T any](target string, newClientFunc func(cc grpc.ClientConnInterface) T, opts ...grpc.DialOption) *RPCConnection[T] {
+	conn := &RPCConnection[T]{
+		Target: target,
+		Opts:   opts,
+	}
+	conn.Client = newClientFunc(conn)
+
+	return conn
+}
+
+// ForceReconnect drops the established gRPC client conn and forces a re-connect at the next client call.
+func (conn *RPCConnection[T]) ForceReconnect() {
+	conn.cc = nil
+}
+
+// Invoke implements [grpc.ClientConnInterface].
+func (conn *RPCConnection[T]) Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) (err error) {
+	// Make sure, this connection is established
+	err = conn.init()
+	if err != nil {
+		return
+	}
+
+	// Then, just forward the request to the embedded client conn
+	err = conn.cc.Invoke(ctx, method, args, reply, opts...)
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		conn.ForceReconnect()
+	}
+
+	return
+}
+
+// NewStream implements [grpc.ClientConnInterface].
+func (conn *RPCConnection[T]) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (stream grpc.ClientStream, err error) {
+	// Make sure, this connection is established
+	err = conn.init()
+	if err != nil {
+		return
+	}
+
+	// Then, just forward the request to the embedded client conn
+	stream, err = conn.cc.NewStream(ctx, desc, method, opts...)
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		conn.ForceReconnect()
+	}
+
+	return
+}
+
+// init takes care of actually establishing the connection to the gRPC server. If the connection is already established,
+// this is a no-op. This function is go-routine safe, because potentially multiple callers could access this at the same
+// time.
+func (conn *RPCConnection[T]) init() (err error) {
+	if conn == nil {
+		return errors.New("RPC connection not configured")
+	}
+
+	// Check, if we already have a valid client connection. We use a read-only lock for a faster access.
+	conn.m.RLock()
+	if conn.cc != nil && conn.cc.GetState() != connectivity.Shutdown {
+		defer conn.m.RUnlock()
+		return nil
+	}
+
+	// If we arrive at this point we need to exchange our read-only lock for a write lock, since we are creating a new
+	// connection and will write to the client conn property.
+	conn.m.RUnlock()
+	conn.m.Lock()
+	defer conn.m.Unlock()
+
+	// Establish a connection to the specified gRPC service
+	conn.cc, err = grpc.Dial(conn.Target,
+		DefaultGrpcDialOptions(conn.Target, conn, conn.Opts...)...,
+	)
+	if err != nil {
+		return fmt.Errorf("could not connect to gPRC target: %w", err)
+	}
+
+	return nil
+}

--- a/cli/session.go
+++ b/cli/session.go
@@ -144,7 +144,7 @@ func (s *Session) Save() (err error) {
 	)
 
 	// create the session directory
-	if err = os.MkdirAll(s.Folder, 0744); err != nil {
+	if err = os.MkdirAll(s.Folder, 0600); err != nil {
 		return fmt.Errorf("could not create .clouditor in home directory: %w", err)
 	}
 

--- a/cmd/engine/engine_test.go
+++ b/cmd/engine/engine_test.go
@@ -41,11 +41,7 @@ func Test_doCmd(t *testing.T) {
 			},
 			want: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
 				discoveryService := i1.(*service_discovery.Service)
-				if !assert.NotNil(t, discoveryService) {
-					return false
-				}
-
-				return assert.NotNil(t, discoveryService.Authorizer())
+				return assert.NotNil(t, discoveryService)
 			},
 		},
 		{

--- a/server/auth_middleware_test.go
+++ b/server/auth_middleware_test.go
@@ -33,12 +33,12 @@ import (
 
 	"clouditor.io/clouditor/internal/testdata"
 	"clouditor.io/clouditor/internal/testutil"
-
-	oauth2 "github.com/oxisto/oauth2go"
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	oauth2 "github.com/oxisto/oauth2go"
+	"github.com/stretchr/testify/assert"
 )
 
 func ValidClaimAssertion(tt assert.TestingT, i1 interface{}, _ ...interface{}) bool {

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -68,11 +68,6 @@ type cachedConfiguration struct {
 	*assessment.MetricConfiguration
 }
 
-type grpcTarget struct {
-	target string
-	opts   []grpc.DialOption
-}
-
 // Service is an implementation of the Clouditor Assessment service. It should not be used directly,
 // but rather the NewService constructor should be used. It implements the AssessmentServer interface.
 type Service struct {
@@ -83,12 +78,11 @@ type Service struct {
 	isEvidenceStoreDisabled bool
 	// evidenceStoreStream sends evidences to the Evidence Store
 	evidenceStoreStreams *api.StreamsOf[evidence.EvidenceStore_StoreEvidencesClient, *evidence.StoreEvidenceRequest]
-	evidenceStoreAddress grpcTarget
+	evidenceStore        *api.RPCConnection[evidence.EvidenceStoreClient]
 
 	// orchestratorStream sends assessment results to the Orchestrator
 	orchestratorStreams *api.StreamsOf[orchestrator.Orchestrator_StoreAssessmentResultsClient, *orchestrator.StoreAssessmentResultRequest]
-	orchestratorClient  orchestrator.OrchestratorClient
-	orchestratorAddress grpcTarget
+	orchestrator        *api.RPCConnection[orchestrator.OrchestratorClient]
 	metricEventStream   orchestrator.Orchestrator_SubscribeMetricChangeEventsClient
 
 	// resultHooks is a list of hook functions that can be used if one wants to be
@@ -103,8 +97,7 @@ type Service struct {
 	// TODO(oxisto): combine with hookMutex and replace with a generic version of a mutex'd map
 	confMutex sync.Mutex
 
-	authorizer api.Authorizer
-	authz      service.AuthorizationStrategy
+	authz service.AuthorizationStrategy
 
 	// pe contains the actual policy evaluation engine we use
 	pe policies.PolicyEval
@@ -131,42 +124,33 @@ func WithoutEvidenceStore() service.Option[Service] {
 // WithEvidenceStoreAddress is an option to configure the evidence store gRPC address.
 func WithEvidenceStoreAddress(address string, opts ...grpc.DialOption) service.Option[Service] {
 	return func(svc *Service) {
-		if address == "" {
-			address = DefaultEvidenceStoreAddress
-		}
-
-		svc.evidenceStoreAddress = grpcTarget{
-			target: address,
-			opts:   opts,
-		}
+		svc.evidenceStore.Target = address
+		svc.evidenceStore.Opts = opts
 	}
 }
 
 // WithOrchestratorAddress is an option to configure the orchestrator gRPC address.
-func WithOrchestratorAddress(address string, opts ...grpc.DialOption) service.Option[Service] {
+func WithOrchestratorAddress(target string, opts ...grpc.DialOption) service.Option[Service] {
 	return func(svc *Service) {
-		if address == "" {
-			address = DefaultOrchestratorAddress
-		}
-
-		svc.orchestratorAddress = grpcTarget{
-			target: address,
-			opts:   opts,
-		}
+		svc.orchestrator.Target = target
+		svc.orchestrator.Opts = opts
 	}
 }
 
 // WithOAuth2Authorizer is an option to use an OAuth 2.0 authorizer
 func WithOAuth2Authorizer(config *clientcredentials.Config) service.Option[Service] {
-	return func(svc *Service) {
-		svc.SetAuthorizer(api.NewOAuthAuthorizerFromClientCredentials(config))
+	return func(s *Service) {
+		auth := api.NewOAuthAuthorizerFromClientCredentials(config)
+		s.evidenceStore.SetAuthorizer(auth)
+		s.orchestrator.SetAuthorizer(auth)
 	}
 }
 
 // WithAuthorizer is an option to use a pre-created authorizer
 func WithAuthorizer(auth api.Authorizer) service.Option[Service] {
-	return func(svc *Service) {
-		svc.SetAuthorizer(auth)
+	return func(s *Service) {
+		s.evidenceStore.SetAuthorizer(auth)
+		s.orchestrator.SetAuthorizer(auth)
 	}
 }
 
@@ -190,25 +174,13 @@ func NewService(opts ...service.Option[Service]) *Service {
 		evidenceStoreStreams: api.NewStreamsOf(api.WithLogger[evidence.EvidenceStore_StoreEvidencesClient, *evidence.StoreEvidenceRequest](log)),
 		orchestratorStreams:  api.NewStreamsOf(api.WithLogger[orchestrator.Orchestrator_StoreAssessmentResultsClient, *orchestrator.StoreAssessmentResultRequest](log)),
 		cachedConfigurations: make(map[string]cachedConfiguration),
+		evidenceStore:        api.NewRPCConnection(DefaultEvidenceStoreAddress, evidence.NewEvidenceStoreClient),
+		orchestrator:         api.NewRPCConnection(DefaultOrchestratorAddress, orchestrator.NewOrchestratorClient),
 	}
 
 	// Apply any options
 	for _, o := range opts {
 		o(svc)
-	}
-
-	// Set to default Evidence Store
-	if svc.evidenceStoreAddress.target == "" {
-		svc.evidenceStoreAddress = grpcTarget{
-			target: DefaultEvidenceStoreAddress,
-		}
-	}
-
-	// Set to default Orchestrator
-	if svc.orchestratorAddress.target == "" {
-		svc.orchestratorAddress = grpcTarget{
-			target: DefaultOrchestratorAddress,
-		}
 	}
 
 	// Set to default Rego package
@@ -225,16 +197,6 @@ func NewService(opts ...service.Option[Service]) *Service {
 	}
 
 	return svc
-}
-
-// SetAuthorizer implements UsesAuthorizer
-func (svc *Service) SetAuthorizer(auth api.Authorizer) {
-	svc.authorizer = auth
-}
-
-// Authorizer implements UsesAuthorizer
-func (svc *Service) Authorizer() api.Authorizer {
-	return svc.authorizer
 }
 
 // AssessEvidence is a method implementation of the assessment interface: It assesses a single evidence
@@ -345,9 +307,9 @@ func (svc *Service) handleEvidence(ev *evidence.Evidence, resourceId string) (re
 	// Send evidence via Evidence Store stream if sending evidences is not disabled
 	if !svc.isEvidenceStoreDisabled {
 		// Get Evidence Store stream
-		channelEvidenceStore, err := svc.evidenceStoreStreams.GetStream(svc.evidenceStoreAddress.target, "Evidence Store", svc.initEvidenceStoreStream, svc.evidenceStoreAddress.opts...)
+		channelEvidenceStore, err := svc.evidenceStoreStreams.GetStream(svc.evidenceStore.Target, "Evidence Store", svc.initEvidenceStoreStream, svc.evidenceStore.Opts...)
 		if err != nil {
-			err = fmt.Errorf("could not get stream to evidence store (%s): %w", svc.evidenceStoreAddress.target, err)
+			err = fmt.Errorf("could not get stream to evidence store (%s): %w", svc.evidenceStore.Target, err)
 
 			go svc.informHooks(nil, err)
 
@@ -357,9 +319,9 @@ func (svc *Service) handleEvidence(ev *evidence.Evidence, resourceId string) (re
 	}
 
 	// Get Orchestrator stream
-	channelOrchestrator, err := svc.orchestratorStreams.GetStream(svc.orchestratorAddress.target, "Orchestrator", svc.initOrchestratorStream, svc.orchestratorAddress.opts...)
+	channelOrchestrator, err := svc.orchestratorStreams.GetStream(svc.orchestrator.Target, "Orchestrator", svc.initOrchestratorStream, svc.orchestrator.Opts...)
 	if err != nil {
-		err = fmt.Errorf("could not get stream to orchestrator (%s): %w", svc.orchestratorAddress.target, err)
+		err = fmt.Errorf("could not get stream to orchestrator (%s): %w", svc.orchestrator.Target, err)
 
 		go svc.informHooks(nil, err)
 
@@ -423,19 +385,13 @@ func (svc *Service) RegisterAssessmentResultHook(assessmentResultsHook func(resu
 }
 
 // initEvidenceStoreStream initializes the stream to the Evidence Store
-func (svc *Service) initEvidenceStoreStream(URL string, additionalOpts ...grpc.DialOption) (stream evidence.EvidenceStore_StoreEvidencesClient, err error) {
-	log.Infof("Trying to establish a connection to evidence store service @ %v", svc.evidenceStoreAddress.target)
+func (svc *Service) initEvidenceStoreStream(target string, _ ...grpc.DialOption) (stream evidence.EvidenceStore_StoreEvidencesClient, err error) {
+	log.Infof("Trying to establish a stream to evidence store service @ %v", target)
 
-	// Establish connection to evidence store gRPC service
-	conn, err := grpc.Dial(URL,
-		api.DefaultGrpcDialOptions(URL, svc, additionalOpts...)...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not connect to evidence store service: %w", err)
-	}
+	// Make sure, that we re-connect
+	svc.evidenceStore.ForceReconnect()
 
-	evidenceStoreClient := evidence.NewEvidenceStoreClient(conn)
-	stream, err = evidenceStoreClient.StoreEvidences(context.Background())
+	stream, err = svc.evidenceStore.Client.StoreEvidences(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("could not set up stream to evidence store for storing evidences: %w", err)
 	}
@@ -446,16 +402,13 @@ func (svc *Service) initEvidenceStoreStream(URL string, additionalOpts ...grpc.D
 }
 
 // initOrchestratorStream initializes the stream to the Orchestrator
-func (svc *Service) initOrchestratorStream(_ string, _ ...grpc.DialOption) (stream orchestrator.Orchestrator_StoreAssessmentResultsClient, err error) {
-	log.Infof("Trying to establish a connection to orchestrator service @ %v", svc.orchestratorAddress.target)
+func (svc *Service) initOrchestratorStream(target string, _ ...grpc.DialOption) (stream orchestrator.Orchestrator_StoreAssessmentResultsClient, err error) {
+	log.Infof("Trying to establish a stream to orchestrator service @ %v", target)
 
-	// Establish connection to orchestrator gRPC service
-	err = svc.initOrchestratorClient()
-	if err != nil {
-		return nil, fmt.Errorf("could not set orchestrator client")
-	}
+	// Make sure, that we re-connect
+	svc.orchestrator.ForceReconnect()
 
-	stream, err = svc.orchestratorClient.StoreAssessmentResults(context.Background())
+	stream, err = svc.orchestrator.Client.StoreAssessmentResults(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("could not set up stream to orchestrator for storing assessment results: %w", err)
 	}
@@ -463,7 +416,7 @@ func (svc *Service) initOrchestratorStream(_ string, _ ...grpc.DialOption) (stre
 	log.Infof("Connected to Orchestrator")
 
 	// TODO(oxisto): We should rewrite our generic StreamsOf to deal with incoming messages
-	svc.metricEventStream, err = svc.orchestratorClient.SubscribeMetricChangeEvents(context.Background(), &orchestrator.SubscribeMetricChangeEventRequest{})
+	svc.metricEventStream, err = svc.orchestrator.Client.SubscribeMetricChangeEvents(context.Background(), &orchestrator.SubscribeMetricChangeEventRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("could not set up stream for listening to metric change events: %w", err)
 	}
@@ -477,12 +430,7 @@ func (svc *Service) initOrchestratorStream(_ string, _ ...grpc.DialOption) (stre
 func (svc *Service) Metrics() (metrics []*assessment.Metric, err error) {
 	var res *orchestrator.ListMetricsResponse
 
-	err = svc.initOrchestratorClient()
-	if err != nil {
-		return nil, fmt.Errorf("could not init orchestrator client")
-	}
-
-	res, err = svc.orchestratorClient.ListMetrics(context.Background(), &orchestrator.ListMetricsRequest{})
+	res, err = svc.orchestrator.Client.ListMetrics(context.Background(), &orchestrator.ListMetricsRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve metric list from orchestrator: %w", err)
 	}
@@ -498,13 +446,8 @@ func (svc *Service) MetricImplementation(lang assessment.MetricImplementation_La
 		return nil, errors.New("unsupported language")
 	}
 
-	err = svc.initOrchestratorClient()
-	if err != nil {
-		return nil, fmt.Errorf("could not set orchestrator client")
-	}
-
 	// Retrieve it from the orchestrator
-	impl, err = svc.orchestratorClient.GetMetricImplementation(context.Background(), &orchestrator.GetMetricImplementationRequest{
+	impl, err = svc.orchestrator.Client.GetMetricImplementation(context.Background(), &orchestrator.GetMetricImplementationRequest{
 		MetricId: metric,
 	})
 	if err != nil {
@@ -531,14 +474,9 @@ func (svc *Service) MetricConfiguration(cloudServiceID, metricID string) (config
 	cache, ok = svc.cachedConfigurations[key]
 	svc.confMutex.Unlock()
 
-	err = svc.initOrchestratorClient()
-	if err != nil {
-		return nil, fmt.Errorf("could not set orchestrator client")
-	}
-
 	// Check if entry is not there or is expired
 	if !ok || cache.cachedAt.After(time.Now().Add(EvictionTime)) {
-		config, err = svc.orchestratorClient.GetMetricConfiguration(context.Background(), &orchestrator.GetMetricConfigurationRequest{
+		config, err = svc.orchestrator.Client.GetMetricConfiguration(context.Background(), &orchestrator.GetMetricConfigurationRequest{
 			CloudServiceId: cloudServiceID,
 			MetricId:       metricID,
 		})
@@ -603,23 +541,4 @@ func (svc *Service) handleMetricEvent(event *orchestrator.MetricChangeEvent) {
 
 	// Forward the event to the policy evaluator
 	_ = svc.pe.HandleMetricEvent(event)
-}
-
-// initOrchestratorClient set the orchestrator client
-func (svc *Service) initOrchestratorClient() error {
-	if svc.orchestratorClient != nil {
-		return nil
-	}
-
-	// Establish connection to orchestrator gRPC service
-	conn, err := grpc.Dial(svc.orchestratorAddress.target,
-		api.DefaultGrpcDialOptions(svc.orchestratorAddress.target, svc, svc.orchestratorAddress.opts...)...,
-	)
-	if err != nil {
-		return fmt.Errorf("could not connect to orchestrator service: %w", err)
-	}
-
-	svc.orchestratorClient = orchestrator.NewOrchestratorClient(conn)
-
-	return nil
 }

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -413,13 +413,15 @@ func (svc *Service) initOrchestratorStream(target string, _ ...grpc.DialOption) 
 		return nil, fmt.Errorf("could not set up stream to orchestrator for storing assessment results: %w", err)
 	}
 
-	log.Infof("Connected to Orchestrator")
+	log.Infof("Stream to StoreAssessmentResults established")
 
 	// TODO(oxisto): We should rewrite our generic StreamsOf to deal with incoming messages
 	svc.metricEventStream, err = svc.orchestrator.Client.SubscribeMetricChangeEvents(context.Background(), &orchestrator.SubscribeMetricChangeEventRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("could not set up stream for listening to metric change events: %w", err)
 	}
+
+	log.Infof("Stream to SubscribeMetricChangeEvents established")
 
 	go svc.recvEventsLoop()
 

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -134,6 +134,31 @@ func TestNewService(t *testing.T) {
 				return assert.True(t, s.isEvidenceStoreDisabled)
 			},
 		},
+		{
+			name: "AssessmentServer with oauth2 authorizer",
+			args: args{
+				opts: []service.Option[Service]{
+					WithOAuth2Authorizer(&clientcredentials.Config{ClientID: "client"}),
+				},
+			},
+			want: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
+				s := i1.(*Service)
+				return assert.NotNil(t, s.orchestrator.Authorizer())
+			},
+		},
+		{
+			name: "AssessmentServer with authorization strategy",
+			args: args{
+				opts: []service.Option[Service]{
+					WithAuthorizationStrategy(servicetest.NewAuthorizationStrategy(true)),
+				},
+			},
+			want: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
+				s := i1.(*Service)
+				a := s.authz.(*servicetest.AuthorizationStrategyMock)
+				return assert.NotNil(t, a)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -921,20 +946,6 @@ func TestService_initOrchestratorStoreStream(t *testing.T) {
 				return assert.Equal(t, codes.Unavailable, s.Code())
 			},
 		},
-		// TODO: Fix test
-		// {
-		// 	name: "Authenticated RPC connection with valid user",
-		// 	args: args{
-		// 		url: "bufnet",
-		// 	},
-		// 	fields: fields{
-		// 		opts: []ServiceOption{
-		// 			WithOrchestratorAddress("bufnet"),
-		// 			WithOAuth2Authorizer(testutil.AuthClientConfig(authPort)),
-		// 			WithAdditionalGRPCOpts(grpc.WithContextDialer(bufConnDialer)),
-		// 		},
-		// 	},
-		// },
 		{
 			name: "Authenticated RPC connection with invalid user",
 			args: args{

--- a/service/assessment/bufconn_test.go
+++ b/service/assessment/bufconn_test.go
@@ -28,6 +28,7 @@ package assessment
 import (
 	"context"
 	"net"
+	"syscall"
 
 	"clouditor.io/clouditor/api/evidence"
 	"clouditor.io/clouditor/api/orchestrator"
@@ -46,6 +47,10 @@ var (
 
 func bufConnDialer(context.Context, string) (net.Conn, error) {
 	return bufConnListener.Dial()
+}
+
+func connectionRefusedDialer(context.Context, string) (net.Conn, error) {
+	return nil, syscall.ECONNREFUSED
 }
 
 // startBufConnServer starts an gRPC listening on a bufconn listener. It exposes

--- a/service/discovery/discovery.go
+++ b/service/discovery/discovery.go
@@ -64,11 +64,6 @@ const (
 
 var log *logrus.Entry
 
-type grpcTarget struct {
-	target string
-	opts   []grpc.DialOption
-}
-
 // DiscoveryEventType defines the event types for [DiscoveryEvent].
 type DiscoveryEventType int
 
@@ -98,13 +93,11 @@ type Service struct {
 	configurations map[discovery.Discoverer]*Configuration
 
 	assessmentStreams *api.StreamsOf[assessment.Assessment_AssessEvidencesClient, *assessment.AssessEvidenceRequest]
-	assessmentAddress grpcTarget
+	assessment        *api.RPCConnection[assessment.AssessmentClient]
 
 	storage persistence.Storage
 
 	scheduler *gocron.Scheduler
-
-	authorizer api.Authorizer
 
 	authz service.AuthorizationStrategy
 
@@ -133,12 +126,10 @@ const (
 type ServiceOption func(*Service)
 
 // WithAssessmentAddress is an option to configure the assessment service gRPC address.
-func WithAssessmentAddress(address string, opts ...grpc.DialOption) ServiceOption {
+func WithAssessmentAddress(target string, opts ...grpc.DialOption) ServiceOption {
 	return func(s *Service) {
-		s.assessmentAddress = grpcTarget{
-			target: address,
-			opts:   opts,
-		}
+		s.assessment.Target = target
+		s.assessment.Opts = opts
 	}
 }
 
@@ -151,8 +142,8 @@ func WithCloudServiceID(ID string) ServiceOption {
 
 // WithOAuth2Authorizer is an option to use an OAuth 2.0 authorizer
 func WithOAuth2Authorizer(config *clientcredentials.Config) ServiceOption {
-	return func(s *Service) {
-		s.SetAuthorizer(api.NewOAuthAuthorizerFromClientCredentials(config))
+	return func(svc *Service) {
+		svc.assessment.SetAuthorizer(api.NewOAuthAuthorizerFromClientCredentials(config))
 	}
 }
 
@@ -186,14 +177,12 @@ func NewService(opts ...ServiceOption) *Service {
 	var err error
 	s := &Service{
 		assessmentStreams: api.NewStreamsOf(api.WithLogger[assessment.Assessment_AssessEvidencesClient, *assessment.AssessEvidenceRequest](log)),
-		assessmentAddress: grpcTarget{
-			target: DefaultAssessmentAddress,
-		},
-		scheduler:      gocron.NewScheduler(time.UTC),
-		configurations: make(map[discovery.Discoverer]*Configuration),
-		Events:         make(chan *DiscoveryEvent),
-		csID:           discovery.DefaultCloudServiceID,
-		authz:          &service.AuthorizationStrategyAllowAll{},
+		assessment:        api.NewRPCConnection(DefaultAssessmentAddress, assessment.NewAssessmentClient),
+		scheduler:         gocron.NewScheduler(time.UTC),
+		configurations:    make(map[discovery.Discoverer]*Configuration),
+		Events:            make(chan *DiscoveryEvent),
+		csID:              discovery.DefaultCloudServiceID,
+		authz:             &service.AuthorizationStrategyAllowAll{},
 	}
 
 	// Apply any options
@@ -212,34 +201,17 @@ func NewService(opts ...ServiceOption) *Service {
 	return s
 }
 
-// SetAuthorizer implements UsesAuthorizer.
-func (svc *Service) SetAuthorizer(auth api.Authorizer) {
-	svc.authorizer = auth
-}
-
-// Authorizer implements UsesAuthorizer.
-func (svc *Service) Authorizer() api.Authorizer {
-	return svc.authorizer
-}
-
 // initAssessmentStream initializes the stream that is used to send evidences to the assessment service.
 // If configured, it uses the Authorizer of the discovery service to authenticate requests to the assessment.
-func (svc *Service) initAssessmentStream(target string, additionalOpts ...grpc.DialOption) (stream assessment.Assessment_AssessEvidencesClient, err error) {
+func (svc *Service) initAssessmentStream(target string, _ ...grpc.DialOption) (stream assessment.Assessment_AssessEvidencesClient, err error) {
 	log.Infof("Trying to establish a connection to assessment service @ %v", target)
 
-	// Establish connection to assessment gRPC service
-	conn, err := grpc.Dial(target,
-		api.DefaultGrpcDialOptions(target, svc, additionalOpts...)...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not connect to assessment service: %w", err)
-	}
-
-	client := assessment.NewAssessmentClient(conn)
+	// Make sure, that we re-connect
+	svc.assessment.ForceReconnect()
 
 	// Set up the stream and store it in our service struct, so we can access it later to actually
 	// send the evidence data
-	stream, err = client.AssessEvidences(context.Background())
+	stream, err = svc.assessment.Client.AssessEvidences(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("could not set up stream for assessing evidences: %w", err)
 	}
@@ -411,9 +383,9 @@ func (svc *Service) StartDiscovery(discoverer discovery.Discoverer) {
 		}
 
 		// Get Evidence Store stream
-		channel, err := svc.assessmentStreams.GetStream(svc.assessmentAddress.target, "Assessment", svc.initAssessmentStream, svc.assessmentAddress.opts...)
+		channel, err := svc.assessmentStreams.GetStream(svc.assessment.Target, "Assessment", svc.initAssessmentStream, svc.assessment.Opts...)
 		if err != nil {
-			err = fmt.Errorf("could not get stream to assessment service (%s): %w", svc.assessmentAddress.target, err)
+			err = fmt.Errorf("could not get stream to assessment service (%s): %w", svc.assessment.Target, err)
 			log.Error(err)
 			continue
 		}

--- a/service/discovery/discovery_test.go
+++ b/service/discovery/discovery_test.go
@@ -80,7 +80,7 @@ func TestNewService(t *testing.T) {
 			},
 			want: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
 				s := i1.(*Service)
-				return assert.Equal(t, "localhost:9091", s.assessmentAddress.target)
+				return assert.Equal(t, "localhost:9091", s.assessment.Target)
 			},
 		},
 		{
@@ -171,7 +171,7 @@ func TestService_StartDiscovery(t *testing.T) {
 			_, _ = svc.assessmentStreams.GetStream("mock", "Assessment", func(target string, additionalOpts ...grpc.DialOption) (stream assessment.Assessment_AssessEvidencesClient, err error) {
 				return mockStream, nil
 			})
-			svc.assessmentAddress = grpcTarget{target: "mock"}
+			svc.assessment = &api.RPCConnection[assessment.AssessmentClient]{Target: "mock"}
 			go svc.StartDiscovery(tt.fields.discoverer)
 
 			if tt.checkEvidence {

--- a/service/discovery/discovery_test.go
+++ b/service/discovery/discovery_test.go
@@ -39,6 +39,7 @@ import (
 	"clouditor.io/clouditor/api/discovery"
 	"clouditor.io/clouditor/api/evidence"
 	"clouditor.io/clouditor/internal/testdata"
+	"clouditor.io/clouditor/internal/testutil"
 	"clouditor.io/clouditor/internal/testutil/clitest"
 	"clouditor.io/clouditor/internal/testutil/servicetest"
 	"clouditor.io/clouditor/internal/util"
@@ -105,6 +106,18 @@ func TestNewService(t *testing.T) {
 			want: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
 				s := i1.(*Service)
 				return assert.Equal(t, &service.AuthorizationStrategyJWT{AllowAllKey: "test"}, s.authz)
+			},
+		},
+		{
+			name: "Create service with option 'WithStorage'",
+			args: args{
+				opts: []ServiceOption{
+					WithStorage(testutil.NewInMemoryStorage(t)),
+				},
+			},
+			want: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
+				s := i1.(*Service)
+				return assert.NotNil(t, s.storage)
 			},
 		},
 	}

--- a/service/evaluation/bufconn_test.go
+++ b/service/evaluation/bufconn_test.go
@@ -28,6 +28,7 @@ package evaluation
 import (
 	"context"
 	"net"
+	"syscall"
 
 	"clouditor.io/clouditor/api/orchestrator"
 	"clouditor.io/clouditor/persistence"
@@ -45,6 +46,10 @@ func newBufConnDialer(storage persistence.Storage) func(context.Context, string)
 	return func(ctx context.Context, s string) (net.Conn, error) {
 		return lis.Dial()
 	}
+}
+
+func connectionRefusedDialer(context.Context, string) (net.Conn, error) {
+	return nil, syscall.ECONNREFUSED
 }
 
 // startBufConnServer starts an gRPC listening on a bufconn listener. It exposes

--- a/service/service.go
+++ b/service/service.go
@@ -25,7 +25,9 @@
 
 package service
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+)
 
 var log *logrus.Entry
 


### PR DESCRIPTION
This PR introduces a new type `RPCConnection`, which bundles all gRPC connection related information into a single struct. This gets rid of the separate `grpcTarget` structs as well as any clients. The new type also automatically initialises the connection, so we can get rid of all `initXXXClient` functions. The `initXXXStream` functions need to stay for now, but maybe we can also get rid of them in the future.

Fixes #1050
