### PR TITLE
Update Go to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module clouditor.io/clouditor
 
-go 1.19
+go 1.20
 
 // runtime dependencies (core)
 require (


### PR DESCRIPTION
Now we can, e.g., wrap/join multiple errors.
Together with newest grpc version introducing handling of wrapped  gRPC errors (see #1101), we can, e.g., do the following:
```
var ErrGRPCError = status.Error(codes.InvalidArgument, "invalid request")
...
return fmt.Errorf("%w: %w", ErrGRPCError, api.ErrEmptyRequest) // note the %w's
```
and check both errors with `errors.Is` and the gRPC code:
```
assert.ErrorIs(t, err, ErrGRPCError) // true
assert.ErrorIs(t, err, api.ErrEmptyRequest)  // true
assert.Equal(t, codes.InvalidArgument, status.Code(err))  // true
```