### PR TITLE
Get context from stream for authorization

### DIFF
--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -152,7 +152,7 @@ func (svc *Service) StoreEvidences(stream evidence.EvidenceStore_StoreEvidencesS
 		evidenceRequest := &evidence.StoreEvidenceRequest{
 			Evidence: req.Evidence,
 		}
-		_, err = svc.StoreEvidence(context.Background(), evidenceRequest)
+		_, err = svc.StoreEvidence(stream.Context(), evidenceRequest)
 		if err != nil {
 			log.Errorf("Error storing evidence: %v", err)
 			// Create response message. The StoreEvidence method does not need that message, so we have to create it here for the stream response.

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -625,7 +625,7 @@ func createStoreEvidenceRequestMocks(count int) []*evidence.StoreEvidenceRequest
 			Evidence: &evidence.Evidence{
 				Id:             uuid.NewString(),
 				ToolId:         fmt.Sprintf("MockToolId-%d", i),
-				CloudServiceId: fmt.Sprintf("MockCloudServiceId-%d", i),
+				CloudServiceId: testdata.MockCloudServiceID,
 				Timestamp:      timestamppb.Now(),
 				Raw:            nil,
 				Resource: toStructWithoutTest(voc.VirtualMachine{
@@ -695,7 +695,7 @@ func (mockStreamer) SetTrailer(_ metadata.MD) {
 }
 
 func (mockStreamer) Context() context.Context {
-	panic("implement me")
+	return context.TODO()
 }
 
 func (mockStreamer) SendMsg(_ interface{}) error {
@@ -710,6 +710,10 @@ type mockStreamerWithRecvErr struct {
 	grpc.ServerStream
 	RecvToServer   chan *evidence.StoreEvidenceRequest
 	SentFromServer chan *evidence.StoreEvidencesResponse
+}
+
+func (*mockStreamerWithRecvErr) Context() context.Context {
+	return context.TODO()
 }
 
 func (mockStreamerWithRecvErr) Send(*evidence.StoreEvidencesResponse) error {
@@ -739,6 +743,10 @@ type mockStreamerWithSendErr struct {
 	grpc.ServerStream
 	RecvToServer   chan *evidence.StoreEvidenceRequest
 	SentFromServer chan *evidence.StoreEvidencesResponse
+}
+
+func (*mockStreamerWithSendErr) Context() context.Context {
+	return context.TODO()
 }
 
 func (*mockStreamerWithSendErr) Send(*evidence.StoreEvidencesResponse) error {

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -289,7 +289,7 @@ func TestService_StoreEvidences(t *testing.T) {
 			if !tt.wantErr {
 				assert.Nil(t, err)
 				assert.Equal(t, tt.wantRespMessage.Status, responseFromServer.Status)
-				// We have to check both ways, as it fails if one message is empty.
+				// We have to check both ways, as it fails if one StatusMessage is empty.
 				assert.Contains(t, responseFromServer.StatusMessage, tt.wantRespMessage.StatusMessage)
 				assert.Contains(t, tt.wantRespMessage.StatusMessage, responseFromServer.StatusMessage)
 			} else {

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -625,7 +625,7 @@ func createStoreEvidenceRequestMocks(count int) []*evidence.StoreEvidenceRequest
 			Evidence: &evidence.Evidence{
 				Id:             uuid.NewString(),
 				ToolId:         fmt.Sprintf("MockToolId-%d", i),
-				CloudServiceId: testdata.MockCloudServiceID,
+				CloudServiceId: fmt.Sprintf("MockCloudServiceId-%d", i),
 				Timestamp:      timestamppb.Now(),
 				Raw:            nil,
 				Resource: toStructWithoutTest(voc.VirtualMachine{

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -288,7 +288,10 @@ func TestService_StoreEvidences(t *testing.T) {
 
 			if !tt.wantErr {
 				assert.Nil(t, err)
+				assert.Equal(t, tt.wantRespMessage.Status, responseFromServer.Status)
+				// We have to check both ways, as it fails if one message is empty.
 				assert.Contains(t, responseFromServer.StatusMessage, tt.wantRespMessage.StatusMessage)
+				assert.Contains(t, tt.wantRespMessage.StatusMessage, responseFromServer.StatusMessage)
 			} else {
 				assert.ErrorContains(t, err, tt.wantErrMessage)
 			}
@@ -625,7 +628,7 @@ func createStoreEvidenceRequestMocks(count int) []*evidence.StoreEvidenceRequest
 			Evidence: &evidence.Evidence{
 				Id:             uuid.NewString(),
 				ToolId:         fmt.Sprintf("MockToolId-%d", i),
-				CloudServiceId: fmt.Sprintf("MockCloudServiceId-%d", i),
+				CloudServiceId: testdata.MockCloudServiceID,
 				Timestamp:      timestamppb.Now(),
 				Raw:            nil,
 				Resource: toStructWithoutTest(voc.VirtualMachine{

--- a/service/orchestrator/assessment_results.go
+++ b/service/orchestrator/assessment_results.go
@@ -215,7 +215,7 @@ func (s *Service) StoreAssessmentResults(stream orchestrator.Orchestrator_StoreA
 		storeAssessmentResultReq := &orchestrator.StoreAssessmentResultRequest{
 			Result: result.Result,
 		}
-		_, err = s.StoreAssessmentResult(context.Background(), storeAssessmentResultReq)
+		_, err = s.StoreAssessmentResult(stream.Context(), storeAssessmentResultReq)
 		if err != nil {
 			// Create response message. The StoreAssessmentResult method does not need that message, so we have to create it here for the stream response.
 			res = &orchestrator.StoreAssessmentResultsResponse{

--- a/service/orchestrator/assessment_results_test.go
+++ b/service/orchestrator/assessment_results_test.go
@@ -975,7 +975,7 @@ func (mockStreamer) SetTrailer(_ metadata.MD) {
 }
 
 func (mockStreamer) Context() context.Context {
-	panic("implement me")
+	return context.TODO()
 }
 
 func (mockStreamer) SendMsg(_ interface{}) error {
@@ -990,6 +990,10 @@ type mockStreamerWithSendErr struct {
 	grpc.ServerStream
 	RecvToServer   chan *orchestrator.StoreAssessmentResultRequest
 	SentFromServer chan *orchestrator.StoreAssessmentResultsResponse
+}
+
+func (mockStreamerWithSendErr) Context() context.Context {
+	return context.TODO()
 }
 
 func (mockStreamerWithSendErr) Send(*orchestrator.StoreAssessmentResultsResponse) error {
@@ -1024,6 +1028,10 @@ type mockStreamerWithRecvErr struct {
 	grpc.ServerStream
 	RecvToServer   chan *orchestrator.StoreAssessmentResultRequest
 	SentFromServer chan *orchestrator.StoreAssessmentResultsResponse
+}
+
+func (mockStreamerWithRecvErr) Context() context.Context {
+	return context.TODO()
 }
 
 func (mockStreamerWithRecvErr) Send(*orchestrator.StoreAssessmentResultsResponse) error {


### PR DESCRIPTION
Fixes #1104 
Fix it in the following streaming RPCs:
- `StoreAssessmentResults`
- `StoreEvidences`