### PR TITLE
Fix assessment crash when assessing corrupt evidence due to metrics cache

### DIFF
--- a/api/evidence/evidence.go
+++ b/api/evidence/evidence.go
@@ -40,7 +40,7 @@ var (
 	ErrResourceNotMap                = errors.New("resource in evidence is not a map")
 	ErrResourceIdMissing             = errors.New("resource in evidence is missing the id field")
 	ErrResourceIdNotString           = errors.New("resource id in evidence is not a string")
-	ErrResourceIdFieldMissing        = errors.New("field id is missing")
+	ErrResourceIdFieldMissing        = errors.New("resource has no id")
 	ErrResourceTypeFieldMissing      = errors.New("field type in evidence is missing")
 	ErrResourceTypeNotArrayOfStrings = errors.New("resource type in evidence is not an array of strings")
 	ErrResourceTypeEmpty             = errors.New("resource type (array) in evidence is empty")

--- a/api/evidence/evidence.go
+++ b/api/evidence/evidence.go
@@ -38,9 +38,9 @@ type EvidenceHookFunc func(result *Evidence, err error)
 var (
 	ErrResourceNotStruct             = errors.New("resource in evidence is not struct value")
 	ErrResourceNotMap                = errors.New("resource in evidence is not a map")
-	ErrResourceIdMissing             = errors.New("resource in evidence is missing the id field")
+	ErrResourceIdIsEmpty             = errors.New("resource id in evidence is empty")
 	ErrResourceIdNotString           = errors.New("resource id in evidence is not a string")
-	ErrResourceIdFieldMissing        = errors.New("resource has no id")
+	ErrResourceIdFieldMissing        = errors.New("resource in evidence is missing the id field")
 	ErrResourceTypeFieldMissing      = errors.New("field type in evidence is missing")
 	ErrResourceTypeNotArrayOfStrings = errors.New("resource type in evidence is not an array of strings")
 	ErrResourceTypeEmpty             = errors.New("resource type (array) in evidence is empty")
@@ -67,7 +67,7 @@ func (evidence *Evidence) ValidateWithResource() (resourceId string, err error) 
 	if !ok {
 		return "", ErrResourceIdFieldMissing
 	} else if field == "" {
-		return "", ErrResourceIdMissing
+		return "", ErrResourceIdIsEmpty
 	}
 
 	resourceId, ok = field.(string)

--- a/api/evidence/evidence_test.go
+++ b/api/evidence/evidence_test.go
@@ -97,7 +97,7 @@ func Test_ValidateEvidence(t *testing.T) {
 				}},
 			wantResp: "",
 			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, ErrResourceIdMissing.Error())
+				return assert.ErrorContains(t, err, ErrResourceIdIsEmpty.Error())
 			},
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module clouditor.io/clouditor
 
-go 1.19
+go 1.20
 
 // runtime dependencies (core)
 require (

--- a/internal/testutil/servicetest/evidencetest/evidence.go
+++ b/internal/testutil/servicetest/evidencetest/evidence.go
@@ -29,7 +29,7 @@ var (
 		Timestamp:      timestamppb.Now(),
 		CloudServiceId: testdata.MockCloudServiceID,
 		ToolId:         testdata.MockEvidenceToolID,
-		Raw:            util.Ref(""),
+		Raw:            util.Ref("This Raw field must be of length >1"),
 		Resource:       structpb.NewNullValue(),
 	}
 	MockEvidence2 = &evidence.Evidence{

--- a/policies/rego.go
+++ b/policies/rego.go
@@ -170,8 +170,9 @@ func (re *regoEval) Eval(evidence *evidence.Evidence, src MetricsSource) (data [
 			// Add runMap to data only if metric was applicable. runMap=nil and err=nil means the metric was not
 			// applicable.
 			// This shouldn't happen in theory since it was tested above when the metric cache got initialized. But when
-			// there is new evidence which has set the resource types correctly (which is the key for the cache), all
-			// metrics are applied due to cache - even when all corresponding resource fields are not set properly.
+			// there is new evidence which has set the resource types and tool id correctly (which is the key for the
+			// cache), all metrics are applied due to cache - even when all corresponding resource fields are not set
+			// properly.
 			if runMap != nil {
 				data = append(data, runMap)
 			}

--- a/policies/rego.go
+++ b/policies/rego.go
@@ -170,9 +170,9 @@ func (re *regoEval) Eval(evidence *evidence.Evidence, src MetricsSource) (data [
 			// Add runMap to data only if metric was applicable. runMap=nil and err=nil means the metric was not
 			// applicable.
 			// This shouldn't happen in theory since it was tested above when the metric cache got initialized. But when
-			// there is new evidence which has set the resource types and tool id correctly (which is the key for the
-			// cache), all metrics are applied due to cache - even when all corresponding resource fields are not set
-			// properly.
+			// there is new evidence which has set the resource types and tool id correctly (their combination builds the
+			// key for the cache), all metrics are applied due to the cache - even when all corresponding resource
+			// fields are not set properly.
 			if runMap != nil {
 				data = append(data, runMap)
 			}

--- a/policies/rego.go
+++ b/policies/rego.go
@@ -167,7 +167,9 @@ func (re *regoEval) Eval(evidence *evidence.Evidence, src MetricsSource) (data [
 			if err != nil {
 				return nil, err
 			}
-
+			if runMap == nil {
+				continue
+			}
 			data = append(data, runMap)
 		}
 	}

--- a/policies/rego.go
+++ b/policies/rego.go
@@ -170,8 +170,8 @@ func (re *regoEval) Eval(evidence *evidence.Evidence, src MetricsSource) (data [
 			// Add runMap to data only if metric was applicable. runMap=nil and err=nil means the metric was not
 			// applicable.
 			// This shouldn't happen in theory since it was tested above when the metric cache got initialized. But when
-			// there is new evidence which has set the resource types and tool id correctly (their combination builds the
-			// key for the cache), all metrics are applied due to the cache - even when all corresponding resource
+			// there is new evidence which has set the resource types and tool id correctly (their combination builds
+			// the key for the cache), all metrics are applied due to the cache - even when all corresponding resource
 			// fields are not set properly.
 			if runMap != nil {
 				data = append(data, runMap)

--- a/policies/rego.go
+++ b/policies/rego.go
@@ -167,10 +167,14 @@ func (re *regoEval) Eval(evidence *evidence.Evidence, src MetricsSource) (data [
 			if err != nil {
 				return nil, err
 			}
-			if runMap == nil {
-				continue
+			// Add runMap to data only if metric was applicable. runMap=nil and err=nil means the metric was not
+			// applicable.
+			// This shouldn't happen in theory since it was tested above when the metric cache got initialized. But when
+			// there is new evidence which has set the resource types correctly (which is the key for the cache), all
+			// metrics are applied due to cache - even when all corresponding resource fields are not set properly.
+			if runMap != nil {
+				data = append(data, runMap)
 			}
-			data = append(data, runMap)
 		}
 	}
 

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -331,7 +331,8 @@ func (svc *Service) handleEvidence(ev *evidence.Evidence, resourceId string) (re
 	for _, data := range evaluations {
 		// That there is an empty (nil) evaluation should be caught beforehand, but you never know.
 		if data == nil {
-			log.Errorf("One empty policy evaluation detected for evidence '%s'. That should not happen.", ev.GetId())
+			log.Errorf("One empty policy evaluation detected for evidence '%s'. That should not happen.",
+				ev.GetId())
 			continue
 		}
 		metricID := data.MetricID

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -329,6 +329,11 @@ func (svc *Service) handleEvidence(ev *evidence.Evidence, resourceId string) (re
 	}
 
 	for _, data := range evaluations {
+		// That there is an empty (nil) evaluation should be caught beforehand, but you never know.
+		if data == nil {
+			log.Error("One empty policy evaluation detected. That should not happen.")
+			continue
+		}
 		metricID := data.MetricID
 
 		log.Debugf("Evaluated evidence %v with metric '%v' as %v", ev.Id, metricID, data.Compliant)

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -331,7 +331,7 @@ func (svc *Service) handleEvidence(ev *evidence.Evidence, resourceId string) (re
 	for _, data := range evaluations {
 		// That there is an empty (nil) evaluation should be caught beforehand, but you never know.
 		if data == nil {
-			log.Error("One empty policy evaluation detected. That should not happen.")
+			log.Errorf("One empty policy evaluation detected for evidence '%s'. That should not happen.", ev.GetId())
 			continue
 		}
 		metricID := data.MetricID

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -47,6 +47,8 @@ import (
 	"clouditor.io/clouditor/policies"
 	"clouditor.io/clouditor/service"
 	"clouditor.io/clouditor/voc"
+
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc"
@@ -370,6 +372,60 @@ func TestService_AssessEvidence(t *testing.T) {
 			assert.Empty(t, gotResp)
 		})
 	}
+}
+
+// TestService_AssessEvidence_DetectMisconfiguredEvidenceEvenWhenAlreadyCached tests the following workflow: First an
+// evidence with a VM resource is assessed. The resource contains all required fields s.t. the metric cache is filled
+// with all applicable metrics. In a second step we assess another evidence. It is also of type "VirtualMachine" but all
+// other fields are not set (e.g. MalwareProtection). Thus, metric will be applied and therefore no error occurs in
+// AssessEvidence-handleEvidence (assessment.go) which loops over all evaluations
+// Todo: Add it to table test above (would probably need some function injection in test cases like we do with storage)
+func TestService_AssessEvidence_DetectMisconfiguredEvidenceEvenWhenAlreadyCached(t *testing.T) {
+	s := &Service{
+		evidenceStore: api.NewRPCConnection(
+			"bufnet", evidence.NewEvidenceStoreClient, grpc.WithContextDialer(bufConnDialer)),
+		orchestrator: api.NewRPCConnection(
+			"bufnet", orchestrator.NewOrchestratorClient, grpc.WithContextDialer(bufConnDialer)),
+		authz: servicetest.NewAuthorizationStrategy(true),
+		evidenceStoreStreams: api.NewStreamsOf(
+			api.WithLogger[evidence.EvidenceStore_StoreEvidencesClient, *evidence.StoreEvidenceRequest](log)),
+		orchestratorStreams: api.NewStreamsOf(
+			api.WithLogger[orchestrator.Orchestrator_StoreAssessmentResultsClient,
+				*orchestrator.StoreAssessmentResultRequest](log)),
+		cachedConfigurations: make(map[string]cachedConfiguration),
+		pe:                   policies.NewRegoEval(policies.WithPackageName(policies.DefaultRegoPackage)),
+	}
+	// First assess evidence with a valid VM resource s.t. the cache is created for the combination of resource type and
+	// tool id (="VirtualMachine-{testdata.MockEvidenceToolID}")
+	e := &evidence.Evidence{
+		Id:        testdata.MockEvidenceID,
+		ToolId:    testdata.MockEvidenceToolID,
+		Timestamp: timestamppb.Now(),
+		// toStruct creates all top level fields of VirtualMachine. Even though their values are nil, the corresponding
+		// metrics are applicable since the fields are present
+		Resource: toStruct(voc.VirtualMachine{
+			Compute: &voc.Compute{
+				Resource: &voc.Resource{ID: testdata.MockResourceID, Type: []string{"VirtualMachine"}}}}, t),
+		CloudServiceId: testdata.MockCloudServiceID}
+	_, err := s.AssessEvidence(context.Background(), &assessment.AssessEvidenceRequest{Evidence: e})
+	assert.NoError(t, err)
+
+	// Now assess a new evidence which has not a valid format other than the resource type and tool id is set correctly
+	r := map[string]any{
+		"type": []any{"VirtualMachine"},
+		"id":   uuid.NewString(),
+	}
+	v, err := structpb.NewValue(r)
+	assert.NoError(t, err)
+	_, err = s.AssessEvidence(context.Background(), &assessment.AssessEvidenceRequest{Evidence: &evidence.Evidence{
+		Id:             uuid.NewString(),
+		Timestamp:      timestamppb.Now(),
+		CloudServiceId: testdata.MockCloudServiceID,
+		ToolId:         testdata.MockEvidenceToolID,
+		Raw:            nil,
+		Resource:       v,
+	}})
+	assert.NoError(t, err)
 }
 
 // TestAssessEvidences tests AssessEvidences

--- a/service/assessment/assessment_test.go
+++ b/service/assessment/assessment_test.go
@@ -327,7 +327,7 @@ func TestService_AssessEvidence(t *testing.T) {
 			},
 			wantResp: nil,
 			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "invalid evidence: resource in evidence is missing the id field")
+				return assert.ErrorContains(t, err, evidence.ErrResourceIdIsEmpty.Error())
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #1106 