### PR TITLE
Stopping gRPC server when hitting ctrl+c

### DIFF
--- a/api/streams.go
+++ b/api/streams.go
@@ -141,6 +141,13 @@ func (s *StreamsOf[StreamType, MsgType]) GetStream(target string, component stri
 	return c, nil
 }
 
+// CloseAll closes all streams
+func (s *StreamsOf[StreamType, MsgType]) CloseAll() {
+	for _, channel := range s.channels {
+		_ = channel.stream.CloseSend()
+	}
+}
+
 // addStream stores a stream to the given component and starts a goroutine for sending messages from the channel to the given component
 func (s *StreamsOf[StreamType, MsgType]) addStream(target string, component string, init InitFuncOf[StreamType], opts ...grpc.DialOption) (c *StreamChannelOf[StreamType, MsgType], err error) {
 	// We need an init func

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -32,7 +32,6 @@ import (
 	"os"
 	"strings"
 
-	"clouditor.io/clouditor/api/assessment"
 	"clouditor.io/clouditor/api/discovery"
 	"clouditor.io/clouditor/api/evaluation"
 	"clouditor.io/clouditor/api/evidence"
@@ -113,9 +112,9 @@ const (
 
 var (
 	srv                  *server.Server
-	discoveryService     discovery.DiscoveryServer
+	discoveryService     *service_discovery.Service
 	orchestratorService  *service_orchestrator.Service
-	assessmentService    assessment.AssessmentServer
+	assessmentService    *service_assessment.Service
 	evidenceStoreService evidence.EvidenceStoreServer
 	evaluationService    evaluation.EvaluationServer
 	db                   persistence.Storage
@@ -390,8 +389,11 @@ func doCmd(_ *cobra.Command, _ []string) (err error) {
 		return err
 	}
 
+	assessmentService.Shutdown()
+	discoveryService.Shutdown()
+
 	log.Infof("Stopping gRPC endpoint")
-	srv.GracefulStop()
+	srv.Stop()
 
 	return nil
 }

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -509,6 +509,11 @@ func (svc *Service) MetricConfiguration(cloudServiceID, metricID string) (config
 	return cache.MetricConfiguration, nil
 }
 
+func (svc *Service) Shutdown() {
+	svc.evidenceStoreStreams.CloseAll()
+	svc.orchestratorStreams.CloseAll()
+}
+
 // recvEventsLoop continuously tries to receive events on the metricEventStream
 func (svc *Service) recvEventsLoop() {
 	for {

--- a/service/discovery/discovery.go
+++ b/service/discovery/discovery.go
@@ -314,6 +314,9 @@ func (svc *Service) Start(ctx context.Context, req *discovery.StartDiscoveryRequ
 }
 
 func (svc *Service) Shutdown() {
+	log.Info("Shutting down discovery service")
+
+	svc.assessmentStreams.CloseAll()
 	svc.scheduler.Stop()
 }
 


### PR DESCRIPTION
The gRPC server was still waiting for some connections when hitting ctrl+c to shutdown. This was because we tried to gracefully shutdown, which did not work because streams were not closed. Now streams are closed properly, but we also need to use Stop() because somehow some connections are still active.

Closes #1141 