### PR TITLE
Update save metrics in loadMetrics()

### DIFF
--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -72,7 +72,8 @@ func (svc *Service) loadMetrics() (err error) {
 	// still need to be aware of the particular metric.
 	for _, m := range metrics {
 		// Somehow, we first need to create the metric, otherwise we are running into weird constraint issues.
-		err = svc.storage.Create(m)
+		// We use Save() instead of Create()because it may be that the metrics already exist in the database and just need to be updated.
+		err = svc.storage.Save(m, "id = ? ", m.Id)
 		if err != nil {
 			log.Errorf("Error while saving metric `%s`: %v", m.Id, err)
 			continue
@@ -84,7 +85,7 @@ func (svc *Service) loadMetrics() (err error) {
 			continue
 		}
 
-		err = svc.storage.Create(m.Implementation)
+		err = svc.storage.Save(m.Implementation, "metric_id = ? ", m.Id)
 		if err != nil {
 			log.Errorf("Error while saving metric implementation for '%s': %v", m.Id, err)
 			continue


### PR DESCRIPTION
This PR updates the storage function from Create() to Save(). 

It is possible that the database already stores metrics and its implementations and on restart the metrics should be updated. If we use Create() we get the error `"NumberOfThreatsFound: unique constraint failed"`. With Save() the metric and its implementation is updated. 