### PR TITLE
QuickFix for UpdateMetricImplementation

### DIFF
--- a/persistence/gorm/gorm.go
+++ b/persistence/gorm/gorm.go
@@ -298,6 +298,7 @@ func (s *storage) Count(r any, conds ...any) (count int64, err error) {
 }
 
 func (s *storage) Save(r any, conds ...any) error {
+	// Save the record
 	tx := applyWhere(s.db, conds...).Save(r)
 	err := tx.Error
 
@@ -305,6 +306,7 @@ func (s *storage) Save(r any, conds ...any) error {
 		return nil
 	}
 
+	// If an error occurs, we try to create the record.
 	err = s.Create(r)
 	if err != nil {
 		return err

--- a/persistence/gorm/gorm.go
+++ b/persistence/gorm/gorm.go
@@ -298,8 +298,9 @@ func (s *storage) Count(r any, conds ...any) (count int64, err error) {
 }
 
 func (s *storage) Save(r any, conds ...any) error {
+	tx := applyWhere(s.db, conds...).Save(r)
+	err := tx.Error
 
-	err := s.Update(r, conds...)
 	if err == nil {
 		return nil
 	}

--- a/persistence/gorm/gorm.go
+++ b/persistence/gorm/gorm.go
@@ -298,12 +298,22 @@ func (s *storage) Count(r any, conds ...any) (count int64, err error) {
 }
 
 func (s *storage) Save(r any, conds ...any) error {
-	tx := applyWhere(s.db, conds...).Save(r)
-	err := tx.Error
 
-	if err != nil && strings.Contains(err.Error(), "constraint failed") {
-		return persistence.ErrConstraintFailed
+	err := s.Update(r, conds...)
+	if err == nil {
+		return nil
 	}
+
+	err = s.Create(r)
+	if err != nil {
+		return err
+	}
+	// tx := applyWhere(s.db, conds...).Save(r)
+	// err := tx.Error
+
+	// if err != nil && strings.Contains(err.Error(), "constraint failed") {
+	// 	return persistence.ErrConstraintFailed
+	// }
 
 	return err
 }

--- a/persistence/gorm/gorm.go
+++ b/persistence/gorm/gorm.go
@@ -308,6 +308,8 @@ func (s *storage) Save(r any, conds ...any) error {
 	if err != nil {
 		return err
 	}
+
+	// TODO (all): Why does it not work properly? See https://github.com/clouditor/clouditor/pull/1175
 	// tx := applyWhere(s.db, conds...).Save(r)
 	// err := tx.Error
 

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -279,11 +279,13 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 	// Update implementation
 	impl = req.Implementation
 	impl.UpdatedAt = timestamppb.Now()
+	var i []*assessment.MetricImplementation
+	i = append(i, impl)
 	log.Warnf("UpdateMetricImplementation: %v", impl)
 	log.Warnf("UpdateMetricImplementation: metricId: %s", impl.MetricId)
 
 	// Store it in the database
-	err = svc.storage.Save(&impl, "metric_id = ?", impl.MetricId)
+	err = svc.storage.Save(i, "metric_id = ?", impl.MetricId)
 	if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
 		return nil, status.Errorf(codes.NotFound, "metric id does not exist")
 	} else if err != nil {

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -279,6 +279,8 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 	// Update implementation
 	impl = req.Implementation
 	impl.UpdatedAt = timestamppb.Now()
+	log.Warnf("UpdateMetricImplementation: %v", impl)
+	log.Warnf("UpdateMetricImplementation: metricId: %s", impl.MetricId)
 
 	// Store it in the database
 	err = svc.storage.Save(&impl, "metric_id = ?", impl.MetricId)

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -279,20 +279,35 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 	// Update implementation
 	impl = req.Implementation
 	impl.UpdatedAt = timestamppb.Now()
-	var i []*assessment.MetricImplementation
-	i = append(i, impl)
 	log.Warnf("UpdateMetricImplementation: %v", impl)
 	log.Warnf("UpdateMetricImplementation: metricId: %s", impl.MetricId)
 
 	// Store it in the database
-	err = svc.storage.Save(i, "metric_id = ?", impl.MetricId)
-	if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
-		return nil, status.Errorf(codes.NotFound, "metric id does not exist")
-	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "database error: %s", err)
+	// First we try to update and if an error occurs we create the entry.
+	// TODO(all): Why is Save() not working properly?
+
+	err = svc.storage.Update(impl, "metric_id = ?", impl.MetricId)
+	if err != nil {
+		log.Debugf("metric implementation for metric %s not available, try to create the metric implementation", impl.MetricId)
+		// Try to create the DB entry.
+		err = svc.storage.Create(impl)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "database error: %v", err)
+		}
 	}
-	// if err != nil {
-	// 	return nil, fmt.Errorf("could not save metric implementation: %w", err)
+
+	// err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
+	// if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
+	// 	return nil, status.Errorf(codes.NotFound, "metric id does not exist")
+	// } else if err != nil {
+	// 	return nil, status.Errorf(codes.Internal, "database error: %s", err)
+	// }
+
+	// err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
+	// if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
+	// 	return nil, status.Errorf(codes.NotFound, "metric id does not exist")
+	// } else if err != nil {
+	// 	return nil, status.Errorf(codes.Internal, "database error: %s", err)
 	// }
 
 	// Notify event listeners

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -281,7 +281,7 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 	impl.UpdatedAt = timestamppb.Now()
 
 	// Store it in the database
-	err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
+	err = svc.storage.Save(&impl, "metric_id = ?", impl.MetricId)
 	if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
 		return nil, status.Errorf(codes.NotFound, "metric id does not exist")
 	} else if err != nil {

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -282,9 +282,14 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 
 	// Store it in the database
 	err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
-	if err != nil {
-		return nil, fmt.Errorf("could not save metric implementation: %w", err)
+	if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
+		return nil, status.Errorf(codes.NotFound, "metric id does not exist")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "database error: %s", err)
 	}
+	// if err != nil {
+	// 	return nil, fmt.Errorf("could not save metric implementation: %w", err)
+	// }
 
 	// Notify event listeners
 	go func() {

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -279,13 +279,9 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 	// Update implementation
 	impl = req.Implementation
 	impl.UpdatedAt = timestamppb.Now()
-	log.Warnf("UpdateMetricImplementation: %v", impl)
-	log.Warnf("UpdateMetricImplementation: metricId: %s", impl.MetricId)
 
 	// Store it in the database
 	// First we try to update and if an error occurs we create the entry.
-	// TODO(all): Why is Save() not working properly?
-
 	err = svc.storage.Update(impl, "metric_id = ?", impl.MetricId)
 	if err != nil {
 		log.Debugf("metric implementation for metric %s not available, try to create the metric implementation", impl.MetricId)
@@ -296,13 +292,7 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 		}
 	}
 
-	// err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
-	// if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
-	// 	return nil, status.Errorf(codes.NotFound, "metric id does not exist")
-	// } else if err != nil {
-	// 	return nil, status.Errorf(codes.Internal, "database error: %s", err)
-	// }
-
+	// TODO(all): Why is Save() not working properly?
 	// err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
 	// if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
 	// 	return nil, status.Errorf(codes.NotFound, "metric id does not exist")

--- a/service/orchestrator/metrics.go
+++ b/service/orchestrator/metrics.go
@@ -282,10 +282,8 @@ func (svc *Service) UpdateMetricImplementation(_ context.Context, req *orchestra
 
 	// Store it in the database
 	err = svc.storage.Save(impl, "metric_id = ?", impl.MetricId)
-	if err != nil && errors.Is(err, persistence.ErrConstraintFailed) {
-		return nil, status.Errorf(codes.NotFound, "metric id does not exist")
-	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "database error: %s", err)
+	if err != nil {
+		return nil, fmt.Errorf("could not save metric implementation: %w", err)
 	}
 
 	// Notify event listeners


### PR DESCRIPTION
**Only merge in Medina branch**

In Medina it is not possible to update a metric_implementation if it not already exists. The following error is returned: 
```
ERROR:
  Code: Unknown
  Message: could not save metric implementation: ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)
```
Locally it works with db_in_memory as well with a postgres DB.

As a quick fix I updated the Save() method in persistence/gorm/gorm.go. It uses now Save() and Create() instead of only Save(). If Save() returns an error it is tried to use Create(). 