### PR TITLE
Harmonize Azure resource ID to all lowercase

### DIFF
--- a/clouditor.code-workspace
+++ b/clouditor.code-workspace
@@ -38,6 +38,7 @@
       "clitest",
       "Clouditor",
       "conds",
+      "dataprotection",
       "Debugf",
       "dialector",
       "discoverytest",
@@ -82,6 +83,7 @@
       "testutil",
       "timestamppb",
       "unmarshalling",
+      "virtualnetworks",
       "Warnf"
     ]
   }

--- a/clouditor.code-workspace
+++ b/clouditor.code-workspace
@@ -71,6 +71,7 @@
       "protoreflect",
       "prototest",
       "Rego",
+      "resourcegroups",
       "resourcemanager",
       "servicetest",
       "sirupsen",

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -10,7 +10,7 @@ const (
 	MockLocationEastUs         = "eastus"
 	MockSubscriptionID         = "00000000-0000-0000-0000-000000000000"
 	MockSubscriptionResourceID = "/subscriptions/00000000-0000-0000-0000-000000000000"
-	MockResourceGroupID        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"
+	MockResourceGroupID        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"
 	MockResourceGroup          = "TestResourceGroup"
 
 	// Auth

--- a/service/discovery/azure/azure_properties.go
+++ b/service/discovery/azure/azure_properties.go
@@ -58,6 +58,15 @@ func resourceID(id *string) string {
 	return strings.ToLower(*id)
 }
 
+func resourceID2(id *string) *string {
+	if id == nil {
+		return nil
+	}
+
+	s := strings.ToLower(*id)
+	return &s
+}
+
 // accountName return the ID's account name
 func accountName(id string) string {
 	if id == "" {

--- a/service/discovery/azure/azure_properties.go
+++ b/service/discovery/azure/azure_properties.go
@@ -48,6 +48,16 @@ func getName(id string) string {
 	return strings.Split(id, "/")[8]
 }
 
+// resourceID makes sure that the Azure ID we get is lowercase, because Azure sometimes has weird notions that things
+// are uppercase. Their documentation says that comparison of IDs is case-insensitive, so we lowercase everything.
+func resourceID(id *string) string {
+	if id == nil {
+		return ""
+	}
+
+	return strings.ToLower(*id)
+}
+
 // accountName return the ID's account name
 func accountName(id string) string {
 	if id == "" {
@@ -171,6 +181,8 @@ func resourceGroupName(id string) string {
 	return strings.Split(id, "/")[4]
 }
 
+// resourceGroupID builds a resource group ID out of the resource ID. It will also be lowercase (see resourceID function
+// for reasoning).
 func resourceGroupID(ID *string) *string {
 	if ID == nil {
 		return nil
@@ -184,7 +196,7 @@ func resourceGroupID(ID *string) *string {
 		return nil
 	}
 
-	id := strings.Join(s[:5], "/")
+	id := strings.ToLower(strings.Join(s[:5], "/"))
 
 	return &id
 }

--- a/service/discovery/azure/azure_test.go
+++ b/service/discovery/azure/azure_test.go
@@ -1351,7 +1351,7 @@ func Test_resourceGroupID(t *testing.T) {
 			args: args{
 				ID: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1/backupInstances/account1-account1-22222222-2222-2222-2222-222222222222"),
 			},
-			want: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+			want: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 		},
 	}
 	for _, tt := range tests {

--- a/service/discovery/azure/backup_handle.go
+++ b/service/discovery/azure/backup_handle.go
@@ -39,7 +39,7 @@ func (d *azureDiscovery) handleInstances(vault *armdataprotection.BackupVaultRes
 
 	if *instance.Properties.DataSourceInfo.DatasourceType == "Microsoft.Storage/storageAccounts/blobServices" {
 		resource = &ontology.ObjectStorage{
-			Id:          util.Deref(instance.ID),
+			Id:          resourceID(instance.ID),
 			Name:        util.Deref(instance.Name),
 			GeoLocation: location(vault.Location),
 			ParentId:    resourceGroupID(instance.ID),
@@ -47,7 +47,7 @@ func (d *azureDiscovery) handleInstances(vault *armdataprotection.BackupVaultRes
 		}
 	} else if *instance.Properties.DataSourceInfo.DatasourceType == "Microsoft.Compute/disks" {
 		resource = &ontology.BlockStorage{
-			Id:          util.Deref(instance.ID),
+			Id:          resourceID(instance.ID),
 			Name:        util.Deref(instance.Name),
 			GeoLocation: location(vault.Location),
 			ParentId:    resourceGroupID(instance.ID),

--- a/service/discovery/azure/backup_test.go
+++ b/service/discovery/azure/backup_test.go
@@ -290,14 +290,14 @@ func Test_azureDiscovery_handleInstances(t *testing.T) {
 				},
 			},
 			wantResource: &ontology.ObjectStorage{
-				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1/backupInstances/account1-account1-22222222-2222-2222-2222-222222222222",
+				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.dataprotection/backupvaults/backupaccount1/backupinstances/account1-account1-22222222-2222-2222-2222-222222222222",
 				Name: "account1-account1-22222222-2222-2222-2222-222222222222",
 				GeoLocation: &ontology.GeoLocation{
 					Region: "westeurope",
 				},
 				CreationTime: nil,
 				Labels:       nil,
-				ParentId:     util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:     util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:          "{\"*armdataprotection.BackupInstanceResource\":[{\"properties\":{\"dataSourceInfo\":{\"datasourceType\":\"Microsoft.Storage/storageAccounts/blobServices\"}},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1/backupInstances/account1-account1-22222222-2222-2222-2222-222222222222\",\"name\":\"account1-account1-22222222-2222-2222-2222-222222222222\"}],\"*armdataprotection.BackupVaultResource\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1\",\"location\":\"westeurope\",\"name\":\"backupAccount1\"}]}",
 			},
 			wantErr: assert.NoError,
@@ -324,14 +324,14 @@ func Test_azureDiscovery_handleInstances(t *testing.T) {
 				},
 			},
 			wantResource: &ontology.BlockStorage{
-				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1/backupInstances/disk1-disk1-22222222-2222-2222-2222-222222222222",
+				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.dataprotection/backupvaults/backupaccount1/backupinstances/disk1-disk1-22222222-2222-2222-2222-222222222222",
 				Name: "disk1-disk1-22222222-2222-2222-2222-222222222222",
 				GeoLocation: &ontology.GeoLocation{
 					Region: "westeurope",
 				},
 				CreationTime: nil,
 				Labels:       nil,
-				ParentId:     util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:     util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:          "{\"*armdataprotection.BackupInstanceResource\":[{\"properties\":{\"dataSourceInfo\":{\"datasourceType\":\"Microsoft.Compute/disks\"}},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1/backupInstances/disk1-disk1-22222222-2222-2222-2222-222222222222\",\"name\":\"disk1-disk1-22222222-2222-2222-2222-222222222222\"}],\"*armdataprotection.BackupVaultResource\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DataProtection/backupVaults/backupAccount1\",\"location\":\"westeurope\",\"name\":\"backupAccount1\"}]}",
 			},
 			wantErr: assert.NoError,

--- a/service/discovery/azure/compute_handle.go
+++ b/service/discovery/azure/compute_handle.go
@@ -76,7 +76,7 @@ func (d *azureDiscovery) handleVirtualMachines(vm *armcompute.VirtualMachine) (o
 	}
 
 	r := &ontology.VirtualMachine{
-		Id:           util.Deref(vm.ID),
+		Id:           resourceID(vm.ID),
 		Name:         util.Deref(vm.Name),
 		CreationTime: creationTime(vm.Properties.TimeCreated),
 		GeoLocation: &ontology.GeoLocation{
@@ -113,18 +113,18 @@ func (d *azureDiscovery) handleVirtualMachines(vm *armcompute.VirtualMachine) (o
 	// Reference to networkInterfaces
 	if vm.Properties.NetworkProfile != nil {
 		for _, networkInterfaces := range vm.Properties.NetworkProfile.NetworkInterfaces {
-			r.NetworkInterfaceIds = append(r.NetworkInterfaceIds, util.Deref(networkInterfaces.ID))
+			r.NetworkInterfaceIds = append(r.NetworkInterfaceIds, resourceID(networkInterfaces.ID))
 		}
 	}
 
 	// Reference to blockstorage
 	if vm.Properties.StorageProfile != nil && vm.Properties.StorageProfile.OSDisk != nil && vm.Properties.StorageProfile.OSDisk.ManagedDisk != nil {
-		r.BlockStorageIds = append(r.BlockStorageIds, util.Deref(vm.Properties.StorageProfile.OSDisk.ManagedDisk.ID))
+		r.BlockStorageIds = append(r.BlockStorageIds, resourceID(vm.Properties.StorageProfile.OSDisk.ManagedDisk.ID))
 	}
 
 	if vm.Properties.StorageProfile != nil && vm.Properties.StorageProfile.DataDisks != nil {
 		for _, blockstorage := range vm.Properties.StorageProfile.DataDisks {
-			r.BlockStorageIds = append(r.BlockStorageIds, util.Deref(blockstorage.ManagedDisk.ID))
+			r.BlockStorageIds = append(r.BlockStorageIds, resourceID(blockstorage.ManagedDisk.ID))
 		}
 	}
 
@@ -154,7 +154,7 @@ func (d *azureDiscovery) handleBlockStorage(disk *armcompute.Disk) (*ontology.Bl
 	backups = backupsEmptyCheck(backups)
 
 	return &ontology.BlockStorage{
-		Id:               util.Deref(disk.ID),
+		Id:               resourceID(disk.ID),
 		Name:             util.Deref(disk.Name),
 		CreationTime:     creationTime(disk.Properties.TimeCreated),
 		GeoLocation:      location(disk.Location),
@@ -207,7 +207,7 @@ func (d *azureDiscovery) handleFunction(function *armappservice.Site, config arm
 	}
 
 	return &ontology.Function{
-		Id:           util.Deref(function.ID),
+		Id:           resourceID(function.ID),
 		Name:         util.Deref(function.Name),
 		CreationTime: nil, // No creation time available
 		GeoLocation: &ontology.GeoLocation{
@@ -237,7 +237,7 @@ func (d *azureDiscovery) handleWebApp(webApp *armappservice.Site, config armapps
 	}
 
 	return &ontology.WebApp{
-		Id:           util.Deref(webApp.ID),
+		Id:           resourceID(webApp.ID),
 		Name:         util.Deref(webApp.Name),
 		CreationTime: nil, // Only the last modified time is available.
 		GeoLocation: &ontology.GeoLocation{

--- a/service/discovery/azure/compute_properties.go
+++ b/service/discovery/azure/compute_properties.go
@@ -134,7 +134,7 @@ func getVirtualNetworkSubnetId(site *armappservice.Site) []string {
 
 	// Get virtual network subnet ID
 	if site.Properties.VirtualNetworkSubnetID != nil {
-		ni = []string{util.Deref(site.Properties.VirtualNetworkSubnetID)}
+		ni = []string{resourceID(site.Properties.VirtualNetworkSubnetID)}
 	}
 
 	return ni

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -73,7 +73,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 
 			want: []ontology.IsResource{
 				&ontology.Function{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/function1",
 					Name:         "function1",
 					CreationTime: nil,
 					Labels: map[string]string{
@@ -83,7 +83,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					GeoLocation: &ontology.GeoLocation{
 						Region: "West Europe",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1\",\"kind\":\"functionapp,linux\",\"location\":\"West Europe\",\"name\":\"function1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"linuxFxVersion\":\"PYTHON|3.8\"}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"name\":\"function1\",\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.1\"},\"type\":\"Microsoft.Web/sites/config\"}]}",
 					NetworkInterfaceIds: []string{},
 					ResourceLogging: &ontology.ResourceLogging{
@@ -104,7 +104,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					RuntimeLanguage: "PYTHON",
 				},
 				&ontology.Function{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/function2",
 					Name:         "function2",
 					CreationTime: nil,
 					Labels: map[string]string{
@@ -114,7 +114,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					GeoLocation: &ontology.GeoLocation{
 						Region: "West Europe",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2\",\"kind\":\"functionapp\",\"location\":\"West Europe\",\"name\":\"function2\",\"properties\":{\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"name\":\"function2\",\"properties\":{\"javaVersion\":\"1.8\"},\"type\":\"Microsoft.Web/sites/config\"}]}",
 					NetworkInterfaceIds: []string{},
 					ResourceLogging: &ontology.ResourceLogging{
@@ -134,7 +134,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					RuntimeLanguage: "Java",
 				},
 				&ontology.WebApp{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/webapp1",
 					Name:         "WebApp1",
 					CreationTime: nil,
 					Labels: map[string]string{
@@ -144,9 +144,9 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					GeoLocation: &ontology.GeoLocation{
 						Region: "West Europe",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp1\",\"properties\":{\"httpsOnly\":true,\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"name\":\"WebApp1\",\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.1\"},\"type\":\"Microsoft.Web/sites/config\"}]}",
-					NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},
+					NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet1"},
 					ResourceLogging: &ontology.ResourceLogging{
 						Enabled: true,
 					},
@@ -162,7 +162,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					Redundancy:   &ontology.Redundancy{},*/
 				},
 				&ontology.WebApp{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/webapp2",
 					Name:         "WebApp2",
 					CreationTime: nil,
 					Labels: map[string]string{
@@ -172,9 +172,9 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 					GeoLocation: &ontology.GeoLocation{
 						Region: "West Europe",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2\",\"kind\":\"app,linux\",\"location\":\"West Europe\",\"name\":\"WebApp2\",\"properties\":{\"httpsOnly\":false,\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"name\":\"WebApp2\",\"properties\":{},\"type\":\"Microsoft.Web/sites/config\"}]}",
-					NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2"},
+					NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet2"},
 					ResourceLogging: &ontology.ResourceLogging{
 						Enabled: false,
 					},
@@ -262,7 +262,7 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 				},
 			},
 			want: &ontology.Function{
-				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1",
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/function1",
 				Name:         "function1",
 				CreationTime: nil,
 				Labels: map[string]string{
@@ -272,7 +272,7 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 				GeoLocation: &ontology.GeoLocation{
 					Region: "West Europe",
 				},
-				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1\",\"kind\":\"functionapp,linux\",\"location\":\"West Europe\",\"name\":\"function1\",\"properties\":{\"httpsOnly\":true,\"resourceGroup\":\"res1\",\"siteConfig\":{\"linuxFxVersion\":\"PYTHON|3.8\"}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
 				NetworkInterfaceIds: []string{},
 				ResourceLogging: &ontology.ResourceLogging{
@@ -325,7 +325,7 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 				},
 			},
 			want: &ontology.Function{
-				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2",
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/function2",
 				Name:         "function2",
 				CreationTime: nil,
 				Labels: map[string]string{
@@ -335,7 +335,7 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 				GeoLocation: &ontology.GeoLocation{
 					Region: "West Europe",
 				},
-				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2\",\"kind\":\"functionapp\",\"location\":\"West Europe\",\"name\":\"function2\",\"properties\":{\"httpsOnly\":true,\"resourceGroup\":\"res1\",\"siteConfig\":{}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"javaVersion\":\"1.8\",\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
 				NetworkInterfaceIds: []string{},
 				ResourceLogging: &ontology.ResourceLogging{
@@ -400,14 +400,14 @@ func Test_azureComputeDiscovery_discoverVirtualMachines(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.VirtualMachine{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/virtualmachines/vm1",
 					Name:         "vm1",
 					CreationTime: timestamppb.New(creationTime),
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armcompute.VirtualMachine\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm1\",\"location\":\"eastus\",\"name\":\"vm1\",\"properties\":{\"diagnosticsProfile\":{\"bootDiagnostics\":{\"enabled\":true,\"storageUri\":\"https://logstoragevm1.blob.core.windows.net/\"}},\"networkProfile\":{\"networkInterfaces\":[{\"id\":\"123\"},{\"id\":\"234\"}]},\"osProfile\":{\"linuxConfiguration\":{\"patchSettings\":{\"patchMode\":\"AutomaticByPlatform\"}}},\"storageProfile\":{\"dataDisks\":[{\"managedDisk\":{\"id\":\"data_disk_1\"}},{\"managedDisk\":{\"id\":\"data_disk_2\"}}],\"osDisk\":{\"managedDisk\":{\"id\":\"os_test_disk\"}}},\"timeCreated\":\"2017-05-24T13:28:53.004540398Z\"},\"resources\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm1/extensions/MicrosoftMonitoringAgent\"}]}]}",
 					NetworkInterfaceIds: []string{"123", "234"},
 					BlockStorageIds:     []string{"os_test_disk", "data_disk_1", "data_disk_2"},
@@ -434,14 +434,14 @@ func Test_azureComputeDiscovery_discoverVirtualMachines(t *testing.T) {
 					},
 				},
 				&ontology.VirtualMachine{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/virtualmachines/vm2",
 					Name:         "vm2",
 					CreationTime: nil,
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armcompute.VirtualMachine\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm2\",\"location\":\"eastus\",\"name\":\"vm2\",\"properties\":{\"diagnosticsProfile\":{\"bootDiagnostics\":{\"enabled\":true}},\"networkProfile\":{\"networkInterfaces\":[{\"id\":\"987\"},{\"id\":\"654\"}]},\"osProfile\":{\"windowsConfiguration\":{\"enableAutomaticUpdates\":true,\"patchSettings\":{\"patchMode\":\"AutomaticByOS\"}}},\"storageProfile\":{\"dataDisks\":[{\"managedDisk\":{\"id\":\"data_disk_2\"}},{\"managedDisk\":{\"id\":\"data_disk_3\"}}],\"osDisk\":{\"managedDisk\":{\"id\":\"os_test_disk\"}}}},\"resources\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm2/extensions/OmsAgentForLinux\"}]}]}",
 					NetworkInterfaceIds: []string{"987", "654"},
 					BlockStorageIds:     []string{"os_test_disk", "data_disk_2", "data_disk_3"},
@@ -467,14 +467,14 @@ func Test_azureComputeDiscovery_discoverVirtualMachines(t *testing.T) {
 					},
 				},
 				&ontology.VirtualMachine{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm3",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/virtualmachines/vm3",
 					Name:         "vm3",
 					CreationTime: nil,
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:                 "{\"*armcompute.VirtualMachine\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm3\",\"location\":\"eastus\",\"name\":\"vm3\",\"properties\":{\"diagnosticsProfile\":{\"bootDiagnostics\":{}}}}]}",
 					NetworkInterfaceIds: []string{},
 					BlockStorageIds:     []string{},
@@ -595,14 +595,14 @@ func Test_azureComputeDiscovery_handleVirtualMachines(t *testing.T) {
 				},
 			},
 			want: &ontology.VirtualMachine{
-				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm1",
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/virtualmachines/vm1",
 				Name:         "vm1",
 				CreationTime: timestamppb.New(creationTime),
 				Labels:       map[string]string{},
 				GeoLocation: &ontology.GeoLocation{
 					Region: "eastus",
 				},
-				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:                 "{\"*armcompute.VirtualMachine\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/virtualMachines/vm1\",\"location\":\"eastus\",\"name\":\"vm1\",\"properties\":{\"diagnosticsProfile\":{\"bootDiagnostics\":{\"enabled\":true,\"storageUri\":\"https://logstoragevm1.blob.core.windows.net/\"}},\"networkProfile\":{\"networkInterfaces\":[{\"id\":\"123\"},{\"id\":\"234\"}]},\"storageProfile\":{\"dataDisks\":[{\"managedDisk\":{\"id\":\"data_disk_1\"}},{\"managedDisk\":{\"id\":\"data_disk_2\"}}],\"osDisk\":{\"managedDisk\":{\"id\":\"os_test_disk\"}}},\"timeCreated\":\"2017-05-24T13:28:53.004540398Z\"}}]}",
 				NetworkInterfaceIds: []string{"123", "234"},
 				BlockStorageIds:     []string{"os_test_disk", "data_disk_1", "data_disk_2"},
@@ -848,14 +848,14 @@ func Test_azureComputeDiscovery_discoverBlockStorage(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.BlockStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/disks/disk1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/disks/disk1",
 					Name:         "disk1",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   map[string]string{},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcompute.Disk\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/disks/disk1\",\"location\":\"eastus\",\"name\":\"disk1\",\"properties\":{\"encryption\":{\"diskEncryptionSetId\":\"\",\"type\":\"EncryptionAtRestWithPlatformKey\"},\"timeCreated\":\"2017-05-24T13:28:53.004540398Z\"},\"type\":\"Microsoft.Compute/disks\"}],\"*armcompute.DiskEncryptionSet\":[null]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -874,14 +874,14 @@ func Test_azureComputeDiscovery_discoverBlockStorage(t *testing.T) {
 					},
 				},
 				&ontology.BlockStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/disks/disk2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/disks/disk2",
 					Name:         "disk2",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   map[string]string{},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcompute.Disk\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/disks/disk2\",\"location\":\"eastus\",\"name\":\"disk2\",\"properties\":{\"encryption\":{\"diskEncryptionSetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/diskEncryptionSets/encryptionkeyvault1\",\"type\":\"EncryptionAtRestWithCustomerKey\"},\"timeCreated\":\"2017-05-24T13:28:53.004540398Z\"},\"type\":\"Microsoft.Compute/disks\"}],\"*armcompute.DiskEncryptionSet\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/diskEncryptionSets/encryption-keyvault1\",\"location\":\"germanywestcentral\",\"name\":\"encryptionkeyvault1\",\"properties\":{\"activeKey\":{\"keyUrl\":\"https://keyvault1.vault.azure.net/keys/customer-key/6273gdb374jz789hjm17819283748382\",\"sourceVault\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.KeyVault/vaults/keyvault1\"}}},\"type\":\"Microsoft.Compute/diskEncryptionSets\"}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_CustomerKeyEncryption{
@@ -901,14 +901,14 @@ func Test_azureComputeDiscovery_discoverBlockStorage(t *testing.T) {
 					},
 				},
 				&ontology.BlockStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res2/providers/Microsoft.Compute/disks/disk3",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res2/providers/microsoft.compute/disks/disk3",
 					Name:         "disk3",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   map[string]string{},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res2"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res2"),
 					Raw:      "{\"*armcompute.Disk\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res2/providers/Microsoft.Compute/disks/disk3\",\"location\":\"eastus\",\"name\":\"disk3\",\"properties\":{\"encryption\":{\"diskEncryptionSetId\":\"\",\"type\":\"EncryptionAtRestWithPlatformKey\"},\"timeCreated\":\"2017-05-24T13:28:53.004540398Z\"},\"type\":\"Microsoft.Compute/disks\"}],\"*armcompute.DiskEncryptionSet\":[null]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -1032,14 +1032,14 @@ func Test_azureComputeDiscovery_handleBlockStorage(t *testing.T) {
 				azureDiscovery: NewMockAzureDiscovery(newMockSender()),
 			},
 			want: &ontology.BlockStorage{
-				Id:           diskID,
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.compute/disks/disk1",
 				Name:         "disk1",
 				CreationTime: timestamppb.New(creationTime),
 				GeoLocation: &ontology.GeoLocation{
 					Region: "eastus",
 				},
 				Labels:   map[string]string{},
-				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:      "{\"*armcompute.Disk\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/disks/disk1\",\"location\":\"eastus\",\"name\":\"disk1\",\"properties\":{\"encryption\":{\"diskEncryptionSetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/diskEncryptionSets/encryptionkeyvault1\",\"type\":\"EncryptionAtRestWithCustomerKey\"},\"timeCreated\":\"2017-05-24T13:28:53.004540398Z\"}}],\"*armcompute.DiskEncryptionSet\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Compute/diskEncryptionSets/encryption-keyvault1\",\"location\":\"germanywestcentral\",\"name\":\"encryptionkeyvault1\",\"properties\":{\"activeKey\":{\"keyUrl\":\"https://keyvault1.vault.azure.net/keys/customer-key/6273gdb374jz789hjm17819283748382\",\"sourceVault\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.KeyVault/vaults/keyvault1\"}}},\"type\":\"Microsoft.Compute/diskEncryptionSets\"}]}",
 				AtRestEncryption: &ontology.AtRestEncryption{
 					Type: &ontology.AtRestEncryption_CustomerKeyEncryption{
@@ -1070,7 +1070,7 @@ func Test_azureComputeDiscovery_handleBlockStorage(t *testing.T) {
 			if !tt.wantErr(t, err, fmt.Sprintf("handleBlockStorage(%v)", tt.args.disk)) {
 				return
 			}
-			assert.Equal(t, tt.want, got)
+			prototest.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1460,7 +1460,7 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 				},
 			},
 			want: &ontology.WebApp{
-				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1",
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/webapp1",
 				Name:         "WebApp1",
 				CreationTime: nil,
 				Labels: map[string]string{
@@ -1470,9 +1470,9 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 				GeoLocation: &ontology.GeoLocation{
 					Region: "West Europe",
 				},
-				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp1\",\"properties\":{\"httpsOnly\":true,\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsVersion\":\"1.2\"},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
-				NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},
+				NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet1"},
 				ResourceLogging: &ontology.ResourceLogging{
 					Enabled: true,
 				},
@@ -1520,7 +1520,7 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 				},
 			},
 			want: &ontology.WebApp{
-				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2",
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.web/sites/webapp2",
 				Name:         "WebApp2",
 				CreationTime: nil,
 				Labels: map[string]string{
@@ -1530,9 +1530,9 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 				GeoLocation: &ontology.GeoLocation{
 					Region: "West Europe",
 				},
-				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:            util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:                 "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp2\",\"properties\":{\"httpsOnly\":false,\"resourceGroup\":\"res1\",\"siteConfig\":{},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{}}]}",
-				NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2"},
+				NetworkInterfaceIds: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet2"},
 				ResourceLogging: &ontology.ResourceLogging{
 					Enabled: false,
 				},
@@ -1559,7 +1559,7 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 				_ = d.initWebAppsClient()
 			}
 
-			assert.Equalf(t, tt.want, d.handleWebApp(tt.args.webApp, tt.args.config), "handleWebApps(%v)", tt.args.webApp)
+			prototest.Equal(t, tt.want, d.handleWebApp(tt.args.webApp, tt.args.config))
 		})
 	}
 }
@@ -1912,7 +1912,7 @@ func Test_getVirtualNetworkSubnetId(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},
+			want: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet1"},
 		},
 		{
 			name: "Happy path: without virtual network subnet ID",

--- a/service/discovery/azure/network_handle.go
+++ b/service/discovery/azure/network_handle.go
@@ -35,7 +35,7 @@ import (
 
 func (d *azureDiscovery) handleLoadBalancer(lb *armnetwork.LoadBalancer) ontology.IsResource {
 	return &ontology.LoadBalancer{
-		Id:           util.Deref(lb.ID),
+		Id:           resourceID(lb.ID),
 		Name:         util.Deref(lb.Name),
 		CreationTime: nil, // No creation time available
 		GeoLocation: &ontology.GeoLocation{
@@ -53,7 +53,7 @@ func (d *azureDiscovery) handleLoadBalancer(lb *armnetwork.LoadBalancer) ontolog
 // NOTE: handleApplicationGateway uses the LoadBalancer for now until there is a own resource
 func (d *azureDiscovery) handleApplicationGateway(ag *armnetwork.ApplicationGateway) ontology.IsResource {
 	return &ontology.LoadBalancer{
-		Id:           util.Deref(ag.ID),
+		Id:           resourceID(ag.ID),
 		Name:         util.Deref(ag.Name),
 		CreationTime: nil, // No creation time available
 		GeoLocation: &ontology.GeoLocation{
@@ -74,7 +74,7 @@ func (d *azureDiscovery) handleApplicationGateway(ag *armnetwork.ApplicationGate
 
 func (d *azureDiscovery) handleNetworkInterfaces(ni *armnetwork.Interface) ontology.IsResource {
 	return &ontology.NetworkInterface{
-		Id:           util.Deref(ni.ID),
+		Id:           resourceID(ni.ID),
 		Name:         util.Deref(ni.Name),
 		CreationTime: nil, // No creation time available
 		GeoLocation: &ontology.GeoLocation{

--- a/service/discovery/azure/network_test.go
+++ b/service/discovery/azure/network_test.go
@@ -65,13 +65,13 @@ func Test_azureNetworkDiscovery_discoverNetworkInterfaces(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.NetworkInterface{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkInterfaces/iface1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/networkinterfaces/iface1",
 					Name: "iface1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   map[string]string{},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armnetwork.Interface\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkInterfaces/iface1\",\"location\":\"eastus\",\"name\":\"iface1\",\"properties\":{\"networkSecurityGroup\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkSecurityGroups/nsg1\",\"location\":\"eastus\"}}}]}",
 					AccessRestriction: &ontology.AccessRestriction{
 						Type: &ontology.AccessRestriction_L3Firewall{
@@ -91,13 +91,13 @@ func Test_azureNetworkDiscovery_discoverNetworkInterfaces(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.NetworkInterface{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkInterfaces/iface1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/networkinterfaces/iface1",
 					Name: "iface1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   map[string]string{},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armnetwork.Interface\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkInterfaces/iface1\",\"location\":\"eastus\",\"name\":\"iface1\",\"properties\":{\"networkSecurityGroup\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkSecurityGroups/nsg1\",\"location\":\"eastus\"}}}]}",
 					AccessRestriction: &ontology.AccessRestriction{
 						Type: &ontology.AccessRestriction_L3Firewall{
@@ -153,40 +153,40 @@ func Test_azureNetworkDiscovery_discoverLoadBalancer(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.LoadBalancer{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/loadbalancers/lb1",
 					Name: "lb1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:        map[string]string{},
 					Raw:           "{\"*armnetwork.LoadBalancer\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1\",\"location\":\"eastus\",\"name\":\"lb1\",\"properties\":{\"frontendIPConfigurations\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/b9cb3645-25d0-4288-910a-020563f63b1c\",\"name\":\"b9cb3645-25d0-4288-910a-020563f63b1c\",\"properties\":{\"publicIPAddress\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/publicIPAddresses/test-b9cb3645-25d0-4288-910a-020563f63b1c\",\"properties\":{\"ipAddress\":\"111.222.333.444\"}}}}],\"loadBalancingRules\":[{\"properties\":{\"frontendPort\":1234}},{\"properties\":{\"frontendPort\":5678}}]}}]}",
-					ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Ips:           []string{"111.222.333.444"},
 					Ports:         []uint32{1234, 5678},
 					HttpEndpoints: []*ontology.HttpEndpoint{},
 				},
 				&ontology.LoadBalancer{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb2",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/loadbalancers/lb2",
 					Name: "lb2",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:        map[string]string{},
 					Raw:           "{\"*armnetwork.LoadBalancer\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb2\",\"location\":\"eastus\",\"name\":\"lb2\",\"properties\":{\"frontendIPConfigurations\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/b9cb3645-25d0-4288-910a-020563f63b1c\",\"name\":\"b9cb3645-25d0-4288-910a-020563f63b1c\",\"properties\":{}}],\"loadBalancingRules\":[{\"properties\":{\"frontendPort\":1234}},{\"properties\":{\"frontendPort\":5678}}]}}]}",
-					ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Ips:           []string{},
 					Ports:         []uint32{1234, 5678},
 					HttpEndpoints: []*ontology.HttpEndpoint{},
 				},
 				&ontology.LoadBalancer{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb3",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/loadbalancers/lb3",
 					Name: "lb3",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:        map[string]string{},
 					Raw:           "{\"*armnetwork.LoadBalancer\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb3\",\"location\":\"eastus\",\"name\":\"lb3\",\"properties\":{\"frontendIPConfigurations\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/b9cb3645-25d0-4288-910a-020563f63b1c\",\"name\":\"b9cb3645-25d0-4288-910a-020563f63b1c\",\"properties\":{\"publicIPAddress\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/publicIPAddresses/test-b9cb3645-25d0-4288-910a-020563f63b1d\"}}}],\"loadBalancingRules\":[{\"properties\":{\"frontendPort\":1234}},{\"properties\":{\"frontendPort\":5678}}]}}]}",
-					ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Ips:           []string{},
 					Ports:         []uint32{1234, 5678},
 					HttpEndpoints: []*ontology.HttpEndpoint{},
@@ -374,14 +374,14 @@ func Test_azureNetworkDiscovery_discoverApplicationGateway(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.LoadBalancer{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/applicationGateways/appgw1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/applicationgateways/appgw1",
 					Name: "appgw1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   map[string]string{},
 					Raw:      "{\"*armnetwork.ApplicationGateway\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/applicationGateways/appgw1\",\"location\":\"eastus\",\"name\":\"appgw1\",\"properties\":{\"webApplicationFirewallConfiguration\":{\"enabled\":true}}}]}",
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					AccessRestriction: &ontology.AccessRestriction{
 						Type: &ontology.AccessRestriction_WebApplicationFirewall{
 							WebApplicationFirewall: &ontology.WebApplicationFirewall{
@@ -535,7 +535,7 @@ func Test_azureDiscovery_handleLoadBalancer(t *testing.T) {
 				},
 			},
 			want: &ontology.LoadBalancer{
-				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1",
+				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/loadbalancers/lb1",
 				Name: "lb1",
 				GeoLocation: &ontology.GeoLocation{
 					Region: "eastus",
@@ -545,7 +545,7 @@ func Test_azureDiscovery_handleLoadBalancer(t *testing.T) {
 					"tag2": "value2",
 				},
 				Raw:           "{\"*armnetwork.LoadBalancer\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/loadBalancers/lb1\",\"location\":\"eastus\",\"name\":\"lb1\",\"properties\":{\"loadBalancingRules\":[]},\"tags\":{\"tag1\":\"value1\",\"tag2\":\"value2\"}}]}",
-				ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId:      util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Ips:           []string{},
 				Ports:         nil,
 				HttpEndpoints: nil,
@@ -593,14 +593,14 @@ func Test_azureDiscovery_handleApplicationGateway(t *testing.T) {
 				},
 			},
 			want: &ontology.LoadBalancer{
-				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/applicationGateways/appgw1",
+				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/applicationgateways/appgw1",
 				Name: "appgw1",
 				GeoLocation: &ontology.GeoLocation{
 					Region: "eastus",
 				},
 				Labels:   map[string]string{},
 				Raw:      "{\"*armnetwork.ApplicationGateway\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/applicationGateways/appgw1\",\"location\":\"eastus\",\"name\":\"appgw1\",\"properties\":{\"webApplicationFirewallConfiguration\":{\"enabled\":true}}}]}",
-				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				AccessRestriction: &ontology.AccessRestriction{
 					Type: &ontology.AccessRestriction_WebApplicationFirewall{
 						WebApplicationFirewall: &ontology.WebApplicationFirewall{
@@ -700,14 +700,14 @@ func Test_azureDiscovery_handleNetworkInterfaces(t *testing.T) {
 				},
 			},
 			want: &ontology.NetworkInterface{
-				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkInterfaces/iface1",
+				Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/networkinterfaces/iface1",
 				Name: "iface1",
 				GeoLocation: &ontology.GeoLocation{
 					Region: "eastus",
 				},
 				Labels:   map[string]string{},
 				Raw:      "{\"*armnetwork.Interface\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkInterfaces/iface1\",\"location\":\"eastus\",\"name\":\"iface1\",\"properties\":{\"networkSecurityGroup\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/networkSecurityGroups/nsg1\",\"location\":\"eastus\"}}}]}",
-				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				AccessRestriction: &ontology.AccessRestriction{
 					Type: &ontology.AccessRestriction_L3Firewall{
 						L3Firewall: &ontology.L3Firewall{

--- a/service/discovery/azure/resource_group_handle.go
+++ b/service/discovery/azure/resource_group_handle.go
@@ -36,7 +36,7 @@ import (
 // handleResourceGroup returns a [voc.Account] out of an existing [armsubscription.Subscription].
 func (d *azureDiscovery) handleResourceGroup(rg *armresources.ResourceGroup) ontology.IsResource {
 	return &ontology.ResourceGroup{
-		Id:          util.Deref(rg.ID),
+		Id:          resourceID(rg.ID),
 		Name:        util.Deref(rg.Name),
 		GeoLocation: location(rg.Location),
 		Labels:      labels(rg.Tags),
@@ -47,7 +47,7 @@ func (d *azureDiscovery) handleResourceGroup(rg *armresources.ResourceGroup) ont
 // handleSubscription returns a [voc.Account] out of an existing [armsubscription.Subscription].
 func (d *azureDiscovery) handleSubscription(s *armsubscription.Subscription) *ontology.Account {
 	return &ontology.Account{
-		Id:           util.Deref(s.ID),
+		Id:           resourceID(s.ID),
 		Name:         util.Deref(s.DisplayName),
 		CreationTime: nil, // subscriptions do not have a creation date
 		GeoLocation:  nil, // subscriptions are global

--- a/service/discovery/azure/resource_group_test.go
+++ b/service/discovery/azure/resource_group_test.go
@@ -168,7 +168,7 @@ func Test_azureResourceGroupDiscovery_discoverResourceGroups(t *testing.T) {
 					Name: "displayName",
 				},
 				&ontology.ResourceGroup{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1",
 					Name: "res1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "westus",
@@ -180,7 +180,7 @@ func Test_azureResourceGroupDiscovery_discoverResourceGroups(t *testing.T) {
 					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000"),
 				},
 				&ontology.ResourceGroup{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res2",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res2",
 					Name: "res2",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
@@ -211,7 +211,7 @@ func Test_azureResourceGroupDiscovery_discoverResourceGroups(t *testing.T) {
 					Name: "displayName",
 				},
 				&ontology.ResourceGroup{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1",
 					Name: "res1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: "westus",

--- a/service/discovery/azure/storage_discover.go
+++ b/service/discovery/azure/storage_discover.go
@@ -108,12 +108,12 @@ func (d *azureDiscovery) discoverMongoDBDatabases(account *armcosmos.DatabaseAcc
 		for _, value := range pageResponse.Value {
 			// Create Cosmos DB database storage voc object
 			mongoDB := &ontology.DatabaseStorage{
-				Id:               util.Deref(value.ID),
+				Id:               resourceID(value.ID),
 				Name:             util.Deref(value.Name),
 				CreationTime:     nil, // creation time of database not available
 				GeoLocation:      location(value.Location),
 				Labels:           labels(value.Tags),
-				ParentId:         account.ID,
+				ParentId:         resourceID2(account.ID),
 				Raw:              discovery.Raw(account, value),
 				AtRestEncryption: atRestEnc,
 			}
@@ -202,12 +202,12 @@ func (d *azureDiscovery) getSqlDBs(server *armsql.Server) ([]ontology.IsResource
 
 			// Create database storage voc object
 			sqlDB := &ontology.DatabaseStorage{
-				Id:           util.Deref(value.ID),
+				Id:           resourceID(value.ID),
 				Name:         util.Deref(value.Name),
 				CreationTime: creationTime(value.Properties.CreationDate),
 				GeoLocation:  location(value.Location),
 				Labels:       labels(value.Tags),
-				ParentId:     server.ID,
+				ParentId:     resourceID2(server.ID),
 				Raw:          discovery.Raw(value),
 				AtRestEncryption: &ontology.AtRestEncryption{
 					Type: &ontology.AtRestEncryption_ManagedKeyEncryption{

--- a/service/discovery/azure/storage_handle.go
+++ b/service/discovery/azure/storage_handle.go
@@ -80,7 +80,7 @@ func (d *azureDiscovery) handleCosmosDB(account *armcosmos.DatabaseAccountGetRes
 	// TODO(oxisto): Actually, CosmosDB is a multi-model database, but for now we just model this as a document
 	// database.
 	dbService := &ontology.DocumentDatabaseService{
-		Id:           util.Deref(account.ID),
+		Id:           resourceID(account.ID),
 		Name:         util.Deref(account.Name),
 		CreationTime: creationTime(account.SystemData.CreatedAt),
 		GeoLocation:  location(account.Location),
@@ -121,7 +121,7 @@ func (d *azureDiscovery) handleSqlServer(server *armsql.Server) ([]ontology.IsRe
 
 	// Create SQL database service voc object for SQL server
 	dbService = &ontology.RelationalDatabaseService{
-		Id:           util.Deref(server.ID),
+		Id:           resourceID(server.ID),
 		Name:         util.Deref(server.Name),
 		CreationTime: nil,
 		GeoLocation:  location(server.Location),
@@ -171,7 +171,7 @@ func (d *azureDiscovery) handleStorageAccount(account *armstorage.Account, stora
 	}
 
 	storageService := &ontology.ObjectStorageService{
-		Id:                  util.Deref(account.ID),
+		Id:                  resourceID(account.ID),
 		Name:                util.Deref(account.Name),
 		StorageIds:          storageResourceIDs,
 		CreationTime:        creationTime(account.Properties.CreationTime),
@@ -217,7 +217,7 @@ func (d *azureDiscovery) handleFileStorage(account *armstorage.Account, fileshar
 	}
 
 	return &ontology.FileStorage{
-		Id:           util.Deref(fileshare.ID),
+		Id:           resourceID(fileshare.ID),
 		Name:         util.Deref(fileshare.Name),
 		CreationTime: creationTime(account.Properties.CreationTime), // We only have the creation time of the storage account the file storage belongs to
 		GeoLocation:  location(account.Location),                    // The location is the same as the storage account
@@ -264,12 +264,12 @@ func (d *azureDiscovery) handleObjectStorage(account *armstorage.Account, contai
 	}
 
 	return &ontology.ObjectStorage{
-		Id:               util.Deref(container.ID),
+		Id:               resourceID(container.ID),
 		Name:             util.Deref(container.Name),
 		CreationTime:     creationTime(account.Properties.CreationTime), // We only have the creation time of the storage account the file storage belongs to
 		GeoLocation:      location(account.Location),                    // The location is the same as the storage account
 		Labels:           labels(account.Tags),                          // The storage account labels the file storage belongs to
-		ParentId:         account.ID,                                    // the storage account is our parent
+		ParentId:         util.Ref(resourceID(account.ID)),              // the storage account is our parent
 		Raw:              discovery.Raw(account, container),
 		AtRestEncryption: enc,
 		Immutability: &ontology.Immutability{

--- a/service/discovery/azure/storage_handle.go
+++ b/service/discovery/azure/storage_handle.go
@@ -222,7 +222,7 @@ func (d *azureDiscovery) handleFileStorage(account *armstorage.Account, fileshar
 		CreationTime: creationTime(account.Properties.CreationTime), // We only have the creation time of the storage account the file storage belongs to
 		GeoLocation:  location(account.Location),                    // The location is the same as the storage account
 		Labels:       labels(account.Tags),                          // The storage account labels the file storage belongs to
-		ParentId:     account.ID,                                    // the storage account is our parent
+		ParentId:     resourceID2(account.ID),                       // the storage account is our parent
 		Raw:          discovery.Raw(account, fileshare),
 		ResourceLogging: &ontology.ResourceLogging{
 			MonitoringEnabled:     monitoringLogDataEnabled,
@@ -269,7 +269,7 @@ func (d *azureDiscovery) handleObjectStorage(account *armstorage.Account, contai
 		CreationTime:     creationTime(account.Properties.CreationTime), // We only have the creation time of the storage account the file storage belongs to
 		GeoLocation:      location(account.Location),                    // The location is the same as the storage account
 		Labels:           labels(account.Tags),                          // The storage account labels the file storage belongs to
-		ParentId:         util.Ref(resourceID(account.ID)),              // the storage account is our parent
+		ParentId:         resourceID2(account.ID),                       // the storage account is our parent
 		Raw:              discovery.Raw(account, container),
 		AtRestEncryption: enc,
 		Immutability: &ontology.Immutability{

--- a/service/discovery/azure/storage_test.go
+++ b/service/discovery/azure/storage_test.go
@@ -268,14 +268,14 @@ func Test_handleFileStorage(t *testing.T) {
 				},
 			},
 			want: &ontology.FileStorage{
-				Id:           fileShareID,
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1/fileservices/default/shares/fileshare1",
 				Name:         fileShareName,
 				CreationTime: timestamppb.New(creationTime),
 				GeoLocation: &ontology.GeoLocation{
 					Region: accountRegion,
 				},
 				Labels:   map[string]string{},
-				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1"),
 				Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"}}}],\"*armstorage.FileShareItem\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/fileshare1\",\"name\":\"fileShare1\"}]}",
 				AtRestEncryption: &ontology.AtRestEncryption{
 					Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -390,14 +390,14 @@ func Test_azureStorageDiscovery_handleStorageAccount(t *testing.T) {
 				},
 			},
 			want: &ontology.ObjectStorageService{
-				Id:           accountID,
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1",
 				Name:         accountName,
 				CreationTime: timestamppb.New(creationTime),
 				GeoLocation: &ontology.GeoLocation{
 					Region: accountRegion,
 				},
 				Labels:   map[string]string{},
-				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 				Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"name\":\"account1\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"},\"minimumTlsVersion\":\"TLS1_2\",\"primaryEndpoints\":{\"blob\":\"https://account1.blob.core.windows.net\"},\"supportsHttpsTrafficOnly\":true}}]}",
 				TransportEncryption: &ontology.TransportEncryption{
 					Enforced:        true,
@@ -515,14 +515,14 @@ func Test_handleObjectStorage(t *testing.T) {
 				},
 			},
 			want: &ontology.ObjectStorage{
-				Id:           containerID,
+				Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1/blobservices/default/containers/container1",
 				Name:         containerName,
 				CreationTime: timestamppb.New(creationTime),
 				GeoLocation: &ontology.GeoLocation{
 					Region: accountRegion,
 				},
 				Labels:   map[string]string{},
-				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+				ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1"),
 				Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"}}}],\"*armstorage.ListContainerItem\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1\",\"name\":\"container1\",\"properties\":{\"hasImmutabilityPolicy\":false,\"publicAccess\":\"None\"}}]}",
 				AtRestEncryption: &ontology.AtRestEncryption{
 					Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -619,14 +619,14 @@ func Test_azureStorageDiscovery_discoverFileStorages(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.FileStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/fileshare1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1/fileservices/default/shares/fileshare1",
 					Name:         "fileshare1",
 					CreationTime: timestamppb.New(creationTime),
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1"),
 					Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"name\":\"account1\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"}}}],\"*armstorage.FileShareItem\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/fileshare1\",\"name\":\"fileshare1\",\"type\":\"Microsoft.Storage/storageAccounts/fileServices/shares\"}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -642,14 +642,14 @@ func Test_azureStorageDiscovery_discoverFileStorages(t *testing.T) {
 					},
 				},
 				&ontology.FileStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/fileshare2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1/fileservices/default/shares/fileshare2",
 					Name:         "fileshare2",
 					CreationTime: timestamppb.New(creationTime),
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1"),
 					Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"name\":\"account1\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"}}}],\"*armstorage.FileShareItem\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/fileshare2\",\"name\":\"fileshare2\",\"type\":\"Microsoft.Storage/storageAccounts/fileServices/shares\"}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -741,14 +741,14 @@ func Test_azureStorageDiscovery_discoverObjectStorages(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.ObjectStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1/blobservices/default/containers/container1",
 					Name:         "container1",
 					CreationTime: timestamppb.New(creationTime),
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1"),
 					Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"name\":\"account1\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"}}}],\"*armstorage.ListContainerItem\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1\",\"name\":\"container1\",\"properties\":{\"hasImmutabilityPolicy\":false,\"publicAccess\":\"Container\"},\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\"}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -773,14 +773,14 @@ func Test_azureStorageDiscovery_discoverObjectStorages(t *testing.T) {
 					PublicAccess: true,
 				},
 				&ontology.ObjectStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1/blobservices/default/containers/container2",
 					Name:         "container2",
 					CreationTime: timestamppb.New(creationTime),
 					Labels:       map[string]string{},
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account1"),
 					Raw:      "{\"*armstorage.Account\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1\",\"location\":\"eastus\",\"name\":\"account1\",\"properties\":{\"creationTime\":\"2017-05-24T13:28:53.004540398Z\",\"encryption\":{\"keySource\":\"Microsoft.Storage\"}}}],\"*armstorage.ListContainerItem\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container2\",\"name\":\"container2\",\"properties\":{\"hasImmutabilityPolicy\":false,\"publicAccess\":\"Container\"},\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\"}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -874,14 +874,14 @@ func Test_azureStorageDiscovery_handleSqlServer(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.RelationalDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.sql/servers/sqlserver1",
 					Name:         "SQLServer1",
 					CreationTime: nil,
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   make(map[string]string),
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armsql.Server\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1\",\"location\":\"eastus\",\"name\":\"SQLServer1\",\"properties\":{\"minimalTlsVersion\":\"1.2\"}}]}",
 					TransportEncryption: &ontology.TransportEncryption{
 						Enabled:         true,
@@ -897,14 +897,14 @@ func Test_azureStorageDiscovery_handleSqlServer(t *testing.T) {
 					},
 				},
 				&ontology.DatabaseStorage{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1/databases/SqlDatabase1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.sql/servers/sqlserver1/databases/sqldatabase1",
 					Name:         "SqlDatabase1",
 					CreationTime: nil,
 					GeoLocation: &ontology.GeoLocation{
 						Region: "eastus",
 					},
 					Labels:   make(map[string]string),
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.sql/servers/sqlserver1"),
 					Raw:      "{\"*armsql.Database\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1/databases/SqlDatabase1\",\"location\":\"eastus\",\"name\":\"SqlDatabase1\",\"properties\":{\"isInfraEncryptionEnabled\":true}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -1063,7 +1063,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1",
 					Name:         "DBAccount1",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1073,11 +1073,11 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"eastus\",\"name\":\"DBAccount1\",\"properties\":{\"keyVaultKeyUri\":\"https://testvault.vault.azure.net/keys/testkey/123456\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"},\"type\":\"Microsoft.DocumentDB/databaseAccounts\"}]}",
 				},
 				&ontology.DatabaseStorage{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1/mongodbdatabases/mongodb1",
 					Name: "mongoDB1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: testdata.MockLocationWestEurope,
@@ -1086,7 +1086,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"eastus\",\"name\":\"DBAccount1\",\"properties\":{\"keyVaultKeyUri\":\"https://testvault.vault.azure.net/keys/testkey/123456\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"},\"type\":\"Microsoft.DocumentDB/databaseAccounts\"}],\"*armcosmos.MongoDBDatabaseGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB1\",\"location\":\"West Europe\",\"name\":\"mongoDB1\",\"properties\":{},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_CustomerKeyEncryption{
@@ -1099,7 +1099,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 					},
 				},
 				&ontology.DatabaseStorage{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB2",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1/mongodbdatabases/mongodb2",
 					Name: "mongoDB2",
 					GeoLocation: &ontology.GeoLocation{
 						Region: testdata.MockLocationEastUs,
@@ -1108,7 +1108,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"eastus\",\"name\":\"DBAccount1\",\"properties\":{\"keyVaultKeyUri\":\"https://testvault.vault.azure.net/keys/testkey/123456\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"},\"type\":\"Microsoft.DocumentDB/databaseAccounts\"}],\"*armcosmos.MongoDBDatabaseGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB2\",\"location\":\"eastus\",\"name\":\"mongoDB2\",\"properties\":{},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_CustomerKeyEncryption{
@@ -1121,7 +1121,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 					},
 				},
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount2",
 					Name:         "DBAccount2",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1131,7 +1131,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount2\",\"kind\":\"MongoDB\",\"location\":\"eastus\",\"name\":\"DBAccount2\",\"properties\":{},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"},\"type\":\"Microsoft.DocumentDB/databaseAccounts\"}]}",
 				},
 			},
@@ -1191,7 +1191,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1",
 					Name:         "DBAccount1",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1201,7 +1201,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"location\":\"West Europe\",\"name\":\"DBAccount1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 				},
 			},
@@ -1232,7 +1232,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1",
 					Name:         "DBAccount1",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1242,7 +1242,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"GlobalDocumentDB\",\"location\":\"West Europe\",\"name\":\"DBAccount1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 				},
 			},
@@ -1273,7 +1273,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1",
 					Name:         "DBAccount1",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1283,7 +1283,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"Parse\",\"location\":\"West Europe\",\"name\":\"DBAccount1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 				},
 			},
@@ -1314,7 +1314,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1",
 					Name:         "DBAccount1",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1324,11 +1324,11 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"West Europe\",\"name\":\"DBAccount1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 				},
 				&ontology.DatabaseStorage{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1/mongodbdatabases/mongodb1",
 					Name: "mongoDB1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: testdata.MockLocationWestEurope,
@@ -1337,7 +1337,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"West Europe\",\"name\":\"DBAccount1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"*armcosmos.MongoDBDatabaseGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB1\",\"location\":\"West Europe\",\"name\":\"mongoDB1\",\"properties\":{},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -1349,7 +1349,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 					},
 				},
 				&ontology.DatabaseStorage{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB2",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1/mongodbdatabases/mongodb2",
 					Name: "mongoDB2",
 					GeoLocation: &ontology.GeoLocation{
 						Region: testdata.MockLocationEastUs,
@@ -1358,7 +1358,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"West Europe\",\"name\":\"DBAccount1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"*armcosmos.MongoDBDatabaseGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB2\",\"location\":\"eastus\",\"name\":\"mongoDB2\",\"properties\":{},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -1397,7 +1397,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DocumentDatabaseService{
-					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount2",
+					Id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount2",
 					Name:         "DBAccount2",
 					CreationTime: timestamppb.New(creationTime),
 					GeoLocation: &ontology.GeoLocation{
@@ -1407,7 +1407,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount2\",\"kind\":\"MongoDB\",\"location\":\"eastus\",\"name\":\"DBAccount2\",\"properties\":{\"keyVaultKeyUri\":\"https://testvault.vault.azure.net/keys/testkey/123456\"},\"systemData\":{\"createdAt\":\"2017-05-24T13:28:53.004540398Z\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 				},
 			},
@@ -1468,7 +1468,7 @@ func Test_azureStorageDiscovery_discoverMongoDBDatabases(t *testing.T) {
 			},
 			want: []ontology.IsResource{
 				&ontology.DatabaseStorage{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB1",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1/mongodbdatabases/mongodb1",
 					Name: "mongoDB1",
 					GeoLocation: &ontology.GeoLocation{
 						Region: testdata.MockLocationWestEurope,
@@ -1477,7 +1477,7 @@ func Test_azureStorageDiscovery_discoverMongoDBDatabases(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"West Europe\",\"name\":\"DBAccount1\"}],\"*armcosmos.MongoDBDatabaseGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB1\",\"location\":\"West Europe\",\"name\":\"mongoDB1\",\"properties\":{},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{
@@ -1489,7 +1489,7 @@ func Test_azureStorageDiscovery_discoverMongoDBDatabases(t *testing.T) {
 					},
 				},
 				&ontology.DatabaseStorage{
-					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB2",
+					Id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1/mongodbdatabases/mongodb2",
 					Name: "mongoDB2",
 					GeoLocation: &ontology.GeoLocation{
 						Region: testdata.MockLocationEastUs,
@@ -1498,7 +1498,7 @@ func Test_azureStorageDiscovery_discoverMongoDBDatabases(t *testing.T) {
 						"testKey1": "testTag1",
 						"testKey2": "testTag2",
 					},
-					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1"),
+					ParentId: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.documentdb/databaseaccounts/dbaccount1"),
 					Raw:      "{\"*armcosmos.DatabaseAccountGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1\",\"kind\":\"MongoDB\",\"location\":\"West Europe\",\"name\":\"DBAccount1\"}],\"*armcosmos.MongoDBDatabaseGetResults\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.DocumentDB/databaseAccounts/DBAccount1/mongodbDatabases/mongoDB2\",\"location\":\"eastus\",\"name\":\"mongoDB2\",\"properties\":{},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}]}",
 					AtRestEncryption: &ontology.AtRestEncryption{
 						Type: &ontology.AtRestEncryption_ManagedKeyEncryption{


### PR DESCRIPTION
Because Azure is annoying.

To avoid issue https://github.com/MicrosoftDocs/azure-docs/issues/36222 we are harmonising all resource (group) IDs to be lowercase. Microsoft says that they compare case-insensitive.
