### PR TITLE
Extend discovery: Fix web app redundancy

### DIFF
--- a/service/discovery/azure/app_service_fake_test.go
+++ b/service/discovery/azure/app_service_fake_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Fraunhofer AISEC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//           $$\                           $$\ $$\   $$\
+//           $$ |                          $$ |\__|  $$ |
+//  $$$$$$$\ $$ | $$$$$$\  $$\   $$\  $$$$$$$ |$$\ $$$$$$\    $$$$$$\   $$$$$$\
+// $$  _____|$$ |$$  __$$\ $$ |  $$ |$$  __$$ |$$ |\_$$  _|  $$  __$$\ $$  __$$\
+// $$ /      $$ |$$ /  $$ |$$ |  $$ |$$ /  $$ |$$ |  $$ |    $$ /  $$ |$$ | \__|
+// $$ |      $$ |$$ |  $$ |$$ |  $$ |$$ |  $$ |$$ |  $$ |$$\ $$ |  $$ |$$ |
+// \$$$$$$\  $$ |\$$$$$   |\$$$$$   |\$$$$$$  |$$ |  \$$$   |\$$$$$   |$$ |
+//  \_______|\__| \______/  \______/  \_______|\__|   \____/  \______/ \__|
+//
+// This file is part of Clouditor Community Edition.
+
+package azure
+
+import (
+	"clouditor.io/clouditor/internal/util"
+	"context"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2/fake"
+)
+
+var FakeFarmServer = fake.PlansServer{}
+
+// init initializes fake functions, e.g. for fake Plans client
+func init() {
+	initFakeFarmServer()
+	// Web App and Function Server will follow
+}
+
+func initFakeFarmServer() {
+	// Set up fake Get Function for Farms
+	FakeFarmServer.Get = func(ctx context.Context, resourceGroupName string, farmName string,
+		options *armappservice.PlansClientGetOptions) (
+		resp azfake.Responder[armappservice.PlansClientGetResponse], errResp azfake.ErrorResponder) {
+		if farmName == "FarmWithZoneRedundancy" {
+			resp.SetResponse(200, armappservice.PlansClientGetResponse{
+				Plan: armappservice.Plan{
+					Properties: &armappservice.PlanProperties{
+						ZoneRedundant: util.Ref(true),
+					},
+				},
+			}, &azfake.SetResponseOptions{})
+		}
+		if farmName == "FarmWithNoRedundancy" {
+			resp.SetResponse(200, armappservice.PlansClientGetResponse{
+				Plan: armappservice.Plan{
+					Properties: &armappservice.PlanProperties{
+						ZoneRedundant: util.Ref(false),
+					},
+				},
+			}, &azfake.SetResponseOptions{})
+		}
+		return
+	}
+}

--- a/service/discovery/azure/azure.go
+++ b/service/discovery/azure/azure.go
@@ -162,8 +162,8 @@ type clients struct {
 	networkSecurityGroupsClient *armnetwork.SecurityGroupsClient
 
 	// AppService
-	sitesClient           *armappservice.WebAppsClient
-	appServiceFarmsClient *armappservice.PlansClient
+	sitesClient *armappservice.WebAppsClient
+	plansClient *armappservice.PlansClient
 
 	// Compute
 	virtualMachinesClient *armcompute.VirtualMachinesClient

--- a/service/discovery/azure/azure.go
+++ b/service/discovery/azure/azure.go
@@ -162,7 +162,8 @@ type clients struct {
 	networkSecurityGroupsClient *armnetwork.SecurityGroupsClient
 
 	// AppService
-	sitesClient *armappservice.WebAppsClient
+	sitesClient           *armappservice.WebAppsClient
+	appServiceFarmsClient *armappservice.PlansClient
 
 	// Compute
 	virtualMachinesClient *armcompute.VirtualMachinesClient

--- a/service/discovery/azure/compute.go
+++ b/service/discovery/azure/compute.go
@@ -232,7 +232,7 @@ func (d *azureComputeDiscovery) discoverFunctionsWebApps() ([]voc.IsCloudResourc
 	}
 
 	// initialize farms client
-	if err := d.initAppServiceFarmsClient(); err != nil {
+	if err := d.initAppServicePlansClient(); err != nil {
 		return nil, err
 	}
 
@@ -991,8 +991,8 @@ func (d *azureComputeDiscovery) initWebAppsClient() (err error) {
 	return
 }
 
-// initWebAppsClient creates the client if not already exists
-func (d *azureComputeDiscovery) initAppServiceFarmsClient() (err error) {
+// initAppServicePlansClient creates the client if not already exists
+func (d *azureComputeDiscovery) initAppServicePlansClient() (err error) {
 	d.clients.plansClient, err = initClient(d.clients.plansClient, d.azureDiscovery, armappservice.NewPlansClient)
 	return
 }

--- a/service/discovery/azure/compute.go
+++ b/service/discovery/azure/compute.go
@@ -357,6 +357,10 @@ func (d *azureComputeDiscovery) handleWebApp(webApp *armappservice.Site, config 
 func (d *azureComputeDiscovery) getRedundancy(app *armappservice.Site) (r *voc.Redundancy) {
 	r = &voc.Redundancy{}
 
+	if app.Properties == nil || app.Properties.ServerFarmID == nil {
+		log.Errorf("Could not look at properties or the Server Farm ID because one of them is empty")
+		return
+	}
 	farmName := getAppServiceFarmName(app.Properties.ServerFarmID)
 	farm, err := d.clients.appServiceFarmsClient.Get(context.TODO(), util.Deref(d.rg), farmName, &armappservice.PlansClientGetOptions{})
 	if err != nil {

--- a/service/discovery/azure/compute.go
+++ b/service/discovery/azure/compute.go
@@ -361,8 +361,8 @@ func (d *azureComputeDiscovery) getRedundancy(app *armappservice.Site) (r *voc.R
 		log.Errorf("Could not look at properties or the Server Farm ID because one of them is empty")
 		return
 	}
-	farmName := getAppServiceFarmName(app.Properties.ServerFarmID)
-	farm, err := d.clients.appServiceFarmsClient.Get(context.TODO(), util.Deref(d.rg), farmName, &armappservice.PlansClientGetOptions{})
+	planName := getAppServicePlanName(app.Properties.ServerFarmID)
+	farm, err := d.clients.plansClient.Get(context.TODO(), util.Deref(d.rg), planName, &armappservice.PlansClientGetOptions{})
 	if err != nil {
 		log.Errorf("Could not get App Service Farm '%s', zone redundancy of web app '%s' is assumed to be false: %v",
 			util.Deref(app.Properties.ServerFarmID), util.Deref(app.Name), err)
@@ -372,11 +372,11 @@ func (d *azureComputeDiscovery) getRedundancy(app *armappservice.Site) (r *voc.R
 	return
 }
 
-// getAppServiceFarmName returns the name for the given ID of a app service farm. If it is wrongly formatted, the empty
-// string will be returned
-// A farm id has the following form:
+// getAppServicePlanName returns the name for the given ID of an app service plan (formerly farm). If it is wrongly
+// formatted, the empty string will be returned
+// A plan/farm id has the following form:
 // "/subscriptions/{subscriptionID}/resourceGroups/{groupName}/providers/Microsoft.Web/serverfarms/{appServicePlanName}"
-func getAppServiceFarmName(id *string) (farmName string) {
+func getAppServicePlanName(id *string) (farmName string) {
 	var ok bool
 	_, farmName, ok = strings.Cut(util.Deref(id),
 		"/Microsoft.Web/serverfarms/")
@@ -833,7 +833,7 @@ func (d *azureComputeDiscovery) initWebAppsClient() (err error) {
 
 // initWebAppsClient creates the client if not already exists
 func (d *azureComputeDiscovery) initAppServiceFarmsClient() (err error) {
-	d.clients.appServiceFarmsClient, err = initClient(d.clients.appServiceFarmsClient, d.azureDiscovery, armappservice.NewPlansClient)
+	d.clients.plansClient, err = initClient(d.clients.plansClient, d.azureDiscovery, armappservice.NewPlansClient)
 	return
 }
 

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -3246,7 +3246,7 @@ func Test_getAppServiceFarmName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.wantFarmName, getAppServiceFarmName(tt.args.id), "getAppServiceFarmName(%v)", tt.args.id)
+			assert.Equalf(t, tt.wantFarmName, getAppServicePlanName(tt.args.id), "getAppServicePlanName(%v)", tt.args.id)
 		})
 	}
 }

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -1578,7 +1578,6 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 				// initialize backup vaults client
 				_ = az.initWebAppsClient()
 			}
-
 			assert.Equalf(t, tt.want, az.handleFunction(tt.args.function, tt.args.config), "handleFunction(%v)", tt.args.function)
 		})
 	}
@@ -3181,8 +3180,7 @@ func Test_getSecretURI(t *testing.T) {
 
 func Test_azureComputeDiscovery_getRedundancy(t *testing.T) {
 	type fields struct {
-		azureDiscovery     *azureDiscovery
-		defenderProperties map[string]*defenderProperties
+		azureDiscovery *azureDiscovery
 	}
 	type args struct {
 		app *armappservice.Site

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -3177,3 +3177,30 @@ func Test_getSecretURI(t *testing.T) {
 		})
 	}
 }
+
+func Test_getAppServiceFarmName(t *testing.T) {
+	type args struct {
+		id *string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantFarmName string
+	}{
+		{
+			name:         "Happy path",
+			args:         args{id: util.Ref("/subscriptions/{subscriptionID}/resourceGroups/{groupName}/providers/Microsoft.Web/serverfarms/appServicePlanName")},
+			wantFarmName: "appServicePlanName",
+		},
+		{
+			name:         "Wrongly formatted id - return empty string",
+			args:         args{id: util.Ref("/SomeNonsense/prefix/appServicePlanName")},
+			wantFarmName: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.wantFarmName, getAppServiceFarmName(tt.args.id), "getAppServiceFarmName(%v)", tt.args.id)
+		})
+	}
+}

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -3303,7 +3303,7 @@ func Test_azureComputeDiscovery_getRedundancy(t *testing.T) {
 			wantR: &voc.Redundancy{Zone: true},
 		},
 		{
-			name: "Web App without zone redundancy enabled",
+			name: "Happy path - zone redundancy disabled",
 			fields: fields{
 				azureDiscovery: NewMockAzureDiscovery(fake.NewPlansServerTransport(&FakeFarmServer)),
 			},
@@ -3312,19 +3312,39 @@ func Test_azureComputeDiscovery_getRedundancy(t *testing.T) {
 					ServerFarmID: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/someRG/providers/Microsoft.Web/serverfarms/FarmWithNoRedundancy")}}},
 			wantR: &voc.Redundancy{Zone: false},
 		},
+		{
+			name: "Missing properties (app.properties is nil) - zone redundancy disabled",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(fake.NewPlansServerTransport(&FakeFarmServer)),
+			},
+			args: args{app: &armappservice.Site{
+				Properties: &armappservice.SiteProperties{
+					ServerFarmID: nil}}},
+			wantR: &voc.Redundancy{Zone: false},
+		},
+		{
+			name: "Missing property (ServerFarmID is nil) - zone redundancy disabled",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(fake.NewPlansServerTransport(&FakeFarmServer)),
+			},
+			args: args{app: &armappservice.Site{
+				Properties: &armappservice.SiteProperties{
+					ServerFarmID: nil}}},
+			wantR: &voc.Redundancy{Zone: false},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &azureComputeDiscovery{
 				azureDiscovery: tt.fields.azureDiscovery,
 			}
-			assert.NoError(t, d.initAppServiceFarmsClient())
+			assert.NoError(t, d.initAppServicePlansClient())
 			assert.Equalf(t, tt.wantR, d.getRedundancy(tt.args.app), "getRedundancy(%v)", tt.args.app)
 		})
 	}
 }
 
-func Test_getAppServiceFarmName(t *testing.T) {
+func Test_getAppServicePlanName(t *testing.T) {
 	type args struct {
 		id *string
 	}


### PR DESCRIPTION
We now finally get the right redundancy mode via App Service Farms