### PR TITLE
Add Diagnostic Settings information to Storage Resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 // indirect dependencies
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.4.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.4.0/go.mod h1:StGsLbuJh06Bd8IBfnAlIFV3fLb+gkczONWf15hpX2E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 h1:Ds0KRF8ggpEGg4Vo42oX1cIt/IfOhHWJBikksZbVxeg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=

--- a/service/discovery/azure/azure.go
+++ b/service/discovery/azure/azure.go
@@ -148,6 +148,7 @@ type clients struct {
 	fileStorageClient        *armstorage.FileSharesClient
 	accountsClient           *armstorage.AccountsClient
 	diagnosticSettingsClient *armmonitor.DiagnosticSettingsClient
+	diagnosticCategoryClient *armmonitor.DiagnosticSettingsCategoryClient
 	tableStorageClient       *armstorage.TableClient
 
 	// DB

--- a/service/discovery/azure/azure.go
+++ b/service/discovery/azure/azure.go
@@ -148,7 +148,6 @@ type clients struct {
 	fileStorageClient        *armstorage.FileSharesClient
 	accountsClient           *armstorage.AccountsClient
 	diagnosticSettingsClient *armmonitor.DiagnosticSettingsClient
-	diagnosticCategoryClient *armmonitor.DiagnosticSettingsCategoryClient
 	tableStorageClient       *armstorage.TableClient
 
 	// DB

--- a/service/discovery/azure/compute.go
+++ b/service/discovery/azure/compute.go
@@ -391,7 +391,7 @@ func (d *azureComputeDiscovery) handleFunction(function *armappservice.Site, con
 			runtimeVersion = *config.Properties.NetFrameworkVersion
 		}
 	}
-	resourceLogging := d.getResourceLoggingWebApp(function)
+	activityLogging := d.getResourceLoggingWebApp(function)
 
 	return &voc.Function{
 		Compute: &voc.Compute{
@@ -410,7 +410,7 @@ func (d *azureComputeDiscovery) handleFunction(function *armappservice.Site, con
 				config,
 			),
 			NetworkInterfaces: []voc.ResourceID{},
-			ResourceLogging:   resourceLogging,
+			ActivityLogging:   activityLogging,
 		},
 		HttpEndpoint: &voc.HttpEndpoint{
 			TransportEncryption: getTransportEncryption(function.Properties, config),
@@ -437,7 +437,7 @@ func (d *azureComputeDiscovery) handleWebApp(webApp *armappservice.Site, config 
 		ni = []voc.ResourceID{voc.ResourceID(resourceID(webApp.Properties.VirtualNetworkSubnetID))}
 	}
 
-	resourceLogging := d.getResourceLoggingWebApp(webApp)
+	activityLogging := d.getResourceLoggingWebApp(webApp)
 
 	// Check if secrets are used and if so, add them to the 'secretUsage' dictionary
 	// Using NewGetAppSettingsKeyVaultReferencesPager would be optimal but is bugged, see https://github.com/Azure/azure-sdk-for-go/issues/14509
@@ -466,7 +466,7 @@ func (d *azureComputeDiscovery) handleWebApp(webApp *armappservice.Site, config 
 				config,
 			),
 			NetworkInterfaces: ni, // Add the Virtual Network Subnet ID
-			ResourceLogging:   resourceLogging,
+			ActivityLogging:   activityLogging,
 		},
 		HttpEndpoint: &voc.HttpEndpoint{
 			TransportEncryption: getTransportEncryption(webApp.Properties, config),
@@ -1127,8 +1127,8 @@ func (d *azureComputeDiscovery) initBackupInstancesClient() (err error) {
 }
 
 // getResourceLoggingWebApp determines if logging is activated for given web app by checking the respective app setting
-func (d *azureComputeDiscovery) getResourceLoggingWebApp(site *armappservice.Site) (rl *voc.ResourceLogging) {
-	rl = &voc.ResourceLogging{Logging: &voc.Logging{}}
+func (d *azureComputeDiscovery) getResourceLoggingWebApp(site *armappservice.Site) (rl *voc.ActivityLogging) {
+	rl = &voc.ActivityLogging{Logging: &voc.Logging{}}
 
 	appSettings, err := d.clients.sitesClient.ListApplicationSettings(context.Background(),
 		*site.Properties.ResourceGroup, *site.Name, &armappservice.WebAppsClientListApplicationSettingsOptions{})

--- a/service/discovery/azure/compute.go
+++ b/service/discovery/azure/compute.go
@@ -391,7 +391,7 @@ func (d *azureComputeDiscovery) handleFunction(function *armappservice.Site, con
 			runtimeVersion = *config.Properties.NetFrameworkVersion
 		}
 	}
-	activityLogging := d.getResourceLoggingWebApp(function)
+	activityLogging := d.getActivityLogging(function)
 
 	return &voc.Function{
 		Compute: &voc.Compute{
@@ -437,7 +437,7 @@ func (d *azureComputeDiscovery) handleWebApp(webApp *armappservice.Site, config 
 		ni = []voc.ResourceID{voc.ResourceID(resourceID(webApp.Properties.VirtualNetworkSubnetID))}
 	}
 
-	activityLogging := d.getResourceLoggingWebApp(webApp)
+	activityLogging := d.getActivityLogging(webApp)
 
 	// Check if secrets are used and if so, add them to the 'secretUsage' dictionary
 	// Using NewGetAppSettingsKeyVaultReferencesPager would be optimal but is bugged, see https://github.com/Azure/azure-sdk-for-go/issues/14509
@@ -1126,8 +1126,10 @@ func (d *azureComputeDiscovery) initBackupInstancesClient() (err error) {
 	return
 }
 
-// getResourceLoggingWebApp determines if logging is activated for given web app by checking the respective app setting
-func (d *azureComputeDiscovery) getResourceLoggingWebApp(site *armappservice.Site) (rl *voc.ActivityLogging) {
+// getResourceLogging determines if logging is activated for a given web app or function by checking the respective app setting
+// In this case logging means the Application Insights logging. The Application Insights logging is automatically forwarded to Log Analytics which is defined in the Diagnostic Settings.
+// TODO(all): Maybe be should discover also the Diagnostic Settings and split the logging from Application Insights and Diagnostic Settings (Log Analytics).
+func (d *azureComputeDiscovery) getActivityLogging(site *armappservice.Site) (rl *voc.ActivityLogging) {
 	rl = &voc.ActivityLogging{Logging: &voc.Logging{}}
 
 	appSettings, err := d.clients.sitesClient.ListApplicationSettings(context.Background(),

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -1120,7 +1120,7 @@ func Test_azureComputeDiscovery_List(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1\",\"kind\":\"functionapp,linux\",\"location\":\"West Europe\",\"name\":\"function1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"linuxFxVersion\":\"PYTHON|3.8\"}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"javaVersion\":\"1.8\",\"linuxFxVersion\":\"\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{
 								Enabled: true,
 							},
@@ -1158,7 +1158,7 @@ func Test_azureComputeDiscovery_List(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2\",\"kind\":\"functionapp\",\"location\":\"West Europe\",\"name\":\"function2\",\"properties\":{\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"javaVersion\":\"1.8\",\"linuxFxVersion\":\"\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{
 								Enabled: false,
 							},
@@ -1196,7 +1196,7 @@ func Test_azureComputeDiscovery_List(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp1\",\"properties\":{\"httpsOnly\":true,\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.1\"},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"linuxFxVersion\":\"\",\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet1"},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{
 								Enabled: true,
 							},
@@ -1232,7 +1232,7 @@ func Test_azureComputeDiscovery_List(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2\",\"kind\":\"app,linux\",\"location\":\"West Europe\",\"name\":\"WebApp2\",\"properties\":{\"httpsOnly\":false,\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsCipherSuite\":\"\",\"minTlsVersion\":\"1.1\"},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"linuxFxVersion\":\"\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet2"},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{
 								Enabled: false,
 							},
@@ -1356,7 +1356,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1\",\"kind\":\"functionapp,linux\",\"location\":\"West Europe\",\"name\":\"function1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"linuxFxVersion\":\"PYTHON|3.8\"}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"javaVersion\":\"1.8\",\"linuxFxVersion\":\"\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{
 								Enabled: true,
 							},
@@ -1394,7 +1394,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2\",\"kind\":\"functionapp\",\"location\":\"West Europe\",\"name\":\"function2\",\"properties\":{\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"javaVersion\":\"1.8\",\"linuxFxVersion\":\"\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{},
 						},
 					},
@@ -1430,7 +1430,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp1\",\"properties\":{\"httpsOnly\":true,\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.1\"},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"linuxFxVersion\":\"\",\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet1"},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{
 								Enabled: true,
 							},
@@ -1466,7 +1466,7 @@ func Test_azureComputeDiscovery_discoverFunctionsWebApps(t *testing.T) {
 							Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2\",\"kind\":\"app,linux\",\"location\":\"West Europe\",\"name\":\"WebApp2\",\"properties\":{\"httpsOnly\":false,\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsCipherSuite\":\"\",\"minTlsVersion\":\"1.1\"},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"linuxFxVersion\":\"\",\"minTlsVersion\":\"1.1\"}}]}",
 						},
 						NetworkInterfaces: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet2"},
-						ResourceLogging: &voc.ResourceLogging{
+						ActivityLogging: &voc.ActivityLogging{
 							Logging: &voc.Logging{},
 						},
 					},
@@ -1580,7 +1580,7 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 						Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function1\",\"kind\":\"functionapp,linux\",\"location\":\"West Europe\",\"name\":\"function1\",\"properties\":{\"httpsOnly\":true,\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"linuxFxVersion\":\"PYTHON|3.8\",\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
 					},
 					NetworkInterfaces: []voc.ResourceID{},
-					ResourceLogging: &voc.ResourceLogging{
+					ActivityLogging: &voc.ActivityLogging{
 						Logging: &voc.Logging{
 							Enabled: true,
 						},
@@ -1654,7 +1654,7 @@ func Test_azureComputeDiscovery_handleFunction(t *testing.T) {
 						Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/function2\",\"kind\":\"functionapp\",\"location\":\"West Europe\",\"name\":\"function2\",\"properties\":{\"httpsOnly\":true,\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
 					},
 					NetworkInterfaces: []voc.ResourceID{},
-					ResourceLogging: &voc.ResourceLogging{
+					ActivityLogging: &voc.ActivityLogging{
 						Logging: &voc.Logging{},
 					},
 				},
@@ -3006,7 +3006,7 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 						Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp1\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp1\",\"properties\":{\"httpsOnly\":true,\"publicNetworkAccess\":\"Enabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{\"minTlsVersion\":\"1.2\"},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
 					},
 					NetworkInterfaces: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet1"},
-					ResourceLogging: &voc.ResourceLogging{
+					ActivityLogging: &voc.ActivityLogging{
 						Logging: &voc.Logging{
 							Enabled: true,
 						},
@@ -3078,7 +3078,7 @@ func Test_azureComputeDiscovery_handleWebApp(t *testing.T) {
 						Raw:    "{\"*armappservice.Site\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Web/sites/WebApp2\",\"kind\":\"app\",\"location\":\"West Europe\",\"name\":\"WebApp2\",\"properties\":{\"httpsOnly\":false,\"publicNetworkAccess\":\"Disabled\",\"resourceGroup\":\"res1\",\"siteConfig\":{},\"virtualNetworkSubnetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet2\"},\"tags\":{\"testKey1\":\"testTag1\",\"testKey2\":\"testTag2\"}}],\"armappservice.WebAppsClientGetConfigurationResponse\":[{\"properties\":{\"minTlsCipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"minTlsVersion\":\"1.2\"}}]}",
 					},
 					NetworkInterfaces: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.network/virtualnetworks/vnet1/subnets/subnet2"},
-					ResourceLogging: &voc.ResourceLogging{
+					ActivityLogging: &voc.ActivityLogging{
 						Logging: &voc.Logging{},
 					},
 				},

--- a/service/discovery/azure/service_fabric.go
+++ b/service/discovery/azure/service_fabric.go
@@ -1,11 +1,12 @@
 package azure
 
 import (
+	"context"
+	"fmt"
+
 	"clouditor.io/clouditor/api/discovery"
 	"clouditor.io/clouditor/internal/util"
 	"clouditor.io/clouditor/voc"
-	"context"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabric/armservicefabric"
 )
 
@@ -94,7 +95,8 @@ func (d *azureServiceFabricDiscovery) discoverClusters() ([]voc.IsCloudResource,
 		clusters = append(clusters, response.Value...)
 	}
 	for _, c := range clusters {
-		var r *voc.Redundancy
+		var r = &voc.Redundancy{}
+
 		if c.Properties.VmssZonalUpgradeMode != nil {
 			r.Zone = true
 		}

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -486,25 +486,25 @@ func (d *azureStorageDiscovery) getActivityLogging(account *armstorage.Account) 
 	// Get ActivityLogging for the storage account
 	activityLoggingAccount, err = d.discoverDiagnosticSettings(util.Deref(account.ID))
 	if err != nil {
-		log.Error("could not discover diagnostic settings for the storage account: %w", err)
+		log.Errorf("could not discover diagnostic settings for the storage account: %v", err)
 	}
 
 	// Get ActivityLogging for the blob service
 	activityLoggingBlob, err = d.discoverDiagnosticSettings(util.Deref(account.ID) + "/blobServices/default")
 	if err != nil {
-		log.Error("could not discover diagnostic settings for the blob service: %w", err)
+		log.Errorf("could not discover diagnostic settings for the blob service: %v", err)
 	}
 
 	// Get ActivityLogging for the table service
 	activityLoggingTable, err = d.discoverDiagnosticSettings(util.Deref(account.ID) + "/tableServices/default")
 	if err != nil {
-		log.Error("could not discover diagnostic settings for the table service: %w", err)
+		log.Errorf("could not discover diagnostic settings for the table service: %v", err)
 	}
 
 	// Get ActivityLogging for the file service
 	activityLoggingFile, err = d.discoverDiagnosticSettings(util.Deref(account.ID) + "/fileServices/default")
 	if err != nil {
-		log.Error("could not discover diagnostic settings for the file service: %w", err)
+		log.Errorf("could not discover diagnostic settings for the file service: %v", err)
 	}
 
 	return
@@ -514,7 +514,7 @@ func (d *azureStorageDiscovery) getActivityLogging(account *armstorage.Account) 
 // discoverDiagnosticSettings discovers the diagnostic setting for the the given resource URI and returns the information of the needed information of the log properties as voc.ActivityLogging object.
 func (d *azureStorageDiscovery) discoverDiagnosticSettings(resourceURI string) (*voc.ActivityLogging, error) {
 	var (
-		al           = &voc.ActivityLogging{}
+		al           *voc.ActivityLogging
 		workspaceIDs []voc.ResourceID
 	)
 
@@ -536,6 +536,7 @@ func (d *azureStorageDiscovery) discoverDiagnosticSettings(resourceURI string) (
 
 			if len(value.Properties.Logs) == 0 {
 				log.Debugf("diagnostic setting '%s' does not send log data to a Log Analytics Workspace", util.Deref(value.Name))
+				continue
 			}
 
 			// Add Log Analytics WorkspaceIDs to slice

--- a/service/discovery/azure/storage_test.go
+++ b/service/discovery/azure/storage_test.go
@@ -409,6 +409,65 @@ func (m mockStorageSender) Do(req *http.Request) (res *http.Response, err error)
 				},
 			},
 		}, 200)
+	} else if req.URL.Path == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/providers/Microsoft.Insights/diagnosticSettings" {
+		return createResponse(req, map[string]interface{}{
+			"value": &[]map[string]interface{}{
+				{
+					"id":   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1",
+					"name": "account1",
+					"properties": map[string]interface{}{
+						"logs": &[]map[string]interface{}{
+							{
+								"enabled": true,
+							},
+						},
+						"workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1",
+					},
+				},
+			},
+		}, 200)
+	} else if req.URL.Path == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account2/providers/Microsoft.Insights/diagnosticSettings" {
+		return createResponse(req, map[string]interface{}{
+			"value": &[]map[string]interface{}{
+				{
+					"id":   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account2",
+					"name": "account2",
+					"properties": map[string]interface{}{
+						"logs": &[]map[string]interface{}{
+							{
+								"enabled": true,
+							},
+						},
+					},
+				},
+			},
+		}, 200)
+	} else if req.URL.Path == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account4/providers/Microsoft.Insights/diagnosticSettings" {
+		return createResponse(req, map[string]interface{}{
+			"value": &[]map[string]interface{}{
+				{
+					"id":   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account4",
+					"name": "account4",
+					"properties": map[string]interface{}{
+						"logs":        &[]map[string]interface{}{},
+						"workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1",
+					},
+				},
+			},
+		}, 200)
+	} else if req.URL.Path == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1/providers/Microsoft.Insights/diagnosticSettings/blobServices/default" {
+		return createResponse(req, map[string]interface{}{
+			"value": &[]map[string]interface{}{
+				{
+					"id":   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1",
+					"name": "account1",
+					"properties": map[string]interface{}{
+						"logs":        &[]map[string]interface{}{},
+						"workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1",
+					},
+				},
+			},
+		}, 200)
 	}
 	return m.mockSender.Do(req)
 }
@@ -723,6 +782,12 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 						Redundancy: &voc.Redundancy{
 							Local: true,
 						},
+						ActivityLogging: &voc.ActivityLogging{
+							Logging: &voc.Logging{
+								Enabled:        true,
+								LoggingService: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1"},
+							},
+						},
 					},
 					HttpEndpoint: &voc.HttpEndpoint{
 						Url: "https://account1.[file,blob].core.windows.net/",
@@ -948,6 +1013,12 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 							},
 						},
 						Redundancy: &voc.Redundancy{},
+						ActivityLogging: &voc.ActivityLogging{
+							Logging: &voc.Logging{
+								Enabled:        true,
+								LoggingService: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1"},
+							},
+						},
 					},
 				},
 				&voc.DatabaseService{
@@ -2537,6 +2608,150 @@ func Test_getCosmosDBRedundancy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.wantR, getCosmosDBRedundancy(tt.args.account), "getCosmosDBRedundancy(%v)", tt.args.account)
+		})
+	}
+}
+
+func Test_azureStorageDiscovery_getActivityLogging(t *testing.T) {
+	type fields struct {
+		azureDiscovery     *azureDiscovery
+		defenderProperties map[string]*defenderProperties
+	}
+	type args struct {
+		account *armstorage.Account
+	}
+	tests := []struct {
+		name                       string
+		fields                     fields
+		args                       args
+		wantActivityLoggingAccount *voc.ActivityLogging
+		wantActivityLoggingBlob    *voc.ActivityLogging
+		wantActivityLoggingTable   *voc.ActivityLogging
+		wantActivityLoggingFile    *voc.ActivityLogging
+	}{
+		{
+			name: "Happy path",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(newMockStorageSender()),
+			},
+			args: args{
+				account: &armstorage.Account{
+					ID: util.Ref("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1"),
+				},
+			},
+			wantActivityLoggingAccount: &voc.ActivityLogging{
+				Logging: &voc.Logging{
+					Enabled:        true,
+					LoggingService: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1"},
+				},
+			},
+			wantActivityLoggingBlob:  nil,
+			wantActivityLoggingTable: nil,
+			wantActivityLoggingFile:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &azureStorageDiscovery{
+				azureDiscovery:     tt.fields.azureDiscovery,
+				defenderProperties: tt.fields.defenderProperties,
+			}
+
+			// Init Diagnostic Settings Client
+			_ = d.initDiagnosticsSettingsClient()
+
+			gotActivityLoggingAccount, gotActivityLoggingBlob, gotActivityLoggingTable, gotActivityLoggingFile := d.getActivityLogging(tt.args.account)
+
+			assert.Equal(t, tt.wantActivityLoggingAccount, gotActivityLoggingAccount)
+			assert.Equal(t, tt.wantActivityLoggingBlob, gotActivityLoggingBlob)
+			assert.Equal(t, tt.wantActivityLoggingTable, gotActivityLoggingTable)
+			assert.Equal(t, tt.wantActivityLoggingFile, gotActivityLoggingFile)
+
+		})
+	}
+}
+
+func Test_azureStorageDiscovery_discoverDiagnosticSettings(t *testing.T) {
+	type fields struct {
+		azureDiscovery     *azureDiscovery
+		defenderProperties map[string]*defenderProperties
+	}
+	type args struct {
+		resourceURI string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *voc.ActivityLogging
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "No Diagnostic Setting available",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(newMockStorageSender()),
+			},
+			args: args{
+				resourceURI: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account3",
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, ErrGettingNextPage.Error())
+			},
+		},
+		{
+			name: "Happy path: no workspace available",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(newMockStorageSender()),
+			},
+			args: args{
+				resourceURI: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account2",
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Happy path: no log settings available",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(newMockStorageSender()),
+			},
+			args: args{
+				resourceURI: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account4",
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Happy path: data logged",
+			fields: fields{
+				azureDiscovery: NewMockAzureDiscovery(newMockStorageSender()),
+			},
+			args: args{
+				resourceURI: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Storage/storageAccounts/account1",
+			},
+			want: &voc.ActivityLogging{
+				Logging: &voc.Logging{
+					Enabled:        true,
+					LoggingService: []voc.ResourceID{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace1"},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &azureStorageDiscovery{
+				azureDiscovery:     tt.fields.azureDiscovery,
+				defenderProperties: tt.fields.defenderProperties,
+			}
+
+			// Init Diagnostic Settings Client
+			_ = d.initDiagnosticsSettingsClient()
+
+			got, err := d.discoverDiagnosticSettings(tt.args.resourceURI)
+
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/voc/compute.go
+++ b/voc/compute.go
@@ -33,4 +33,5 @@ type Compute struct {
 	*Resource
 	NetworkInterfaces []ResourceID     `json:"networkInterfaces"`
 	ResourceLogging   *ResourceLogging `json:"resourceLogging"`
+	ActivityLogging   *ActivityLogging `json:"activityLogging"`
 }

--- a/voc/storage.go
+++ b/voc/storage.go
@@ -36,4 +36,5 @@ type Storage struct {
 	Immutability     *Immutability      `json:"immutability"`
 	Redundancy       *Redundancy        `json:"redundancy"`
 	ResourceLogging  *ResourceLogging   `json:"resourceLogging"`
+	ActivityLogging  *ActivityLogging   `json:"activityLogging"`
 }

--- a/voc/storage_service.go
+++ b/voc/storage_service.go
@@ -32,6 +32,7 @@ var StorageServiceType = []string{"StorageService", "NetworkService", "Networkin
 // StorageService is an entity in our Cloud ontology. This entity represents a network-based service that can be used to access a particular storage backend. It has multiple subclasses, e.g., for databases or object stores. It has a list of storage resources associated to it.
 type StorageService struct {
 	*NetworkService
-	Redundancy *Redundancy  `json:"redundancy"`
-	Storage    []ResourceID `json:"storage"`
+	Redundancy      *Redundancy      `json:"redundancy"`
+	Storage         []ResourceID     `json:"storage"`
+	ActivityLogging *ActivityLogging `json:"activityLogging"`
 }


### PR DESCRIPTION
This PR adds the Diagnostic Settings from the storage account and blob/table/file service as ActivitityLogging to the following resources
- [x] StorageService (Storage Account)
- [x] ObjectStorage
- [x] DatabaseStorage
- [x] FileStorage

Further changes: 
- [x]  CosmosDB Diagnostic Settings are added as ActivityLogging forStorageService (CosmosDB)
- [x] Change ResourceLogging -> ActivityLogging for WebApp/Function