### PR TITLE
Extend Discovery: Fix public network access

### DIFF
--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -3493,3 +3493,35 @@ func Test_azureComputeDiscovery_handleVirtualMachineScaleSet(t *testing.T) {
 		})
 	}
 }
+
+func Test_getSlotBaseName(t *testing.T) {
+	type args struct {
+		nameWithWebAppPrefix *string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Happy path",
+			args: args{nameWithWebAppPrefix: util.Ref("someWebApp/someSlot")},
+			want: "someSlot",
+		},
+		{
+			name: "Invalid web app name 1 (no slash) - return empty string",
+			args: args{nameWithWebAppPrefix: util.Ref("someWebApp")},
+			want: "",
+		},
+		{
+			name: "Invalid web app name 1 (too many slashes) - return empty string",
+			args: args{nameWithWebAppPrefix: util.Ref("someWeirdStuff/WithAnother/someSlot")},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getSlotBaseName(tt.args.nameWithWebAppPrefix), "getSlotBaseName(%v)", tt.args.nameWithWebAppPrefix)
+		})
+	}
+}

--- a/service/discovery/azure/key_vault.go
+++ b/service/discovery/azure/key_vault.go
@@ -259,11 +259,16 @@ func (d *azureKeyVaultDiscovery) handleKeyVault(kv *armkeyvault.Vault) (*voc.Key
 	}, nil
 }
 
+// TODO(lebogg): Test in Az-Testbed
 func getPublicAccess(kv *armkeyvault.Vault) bool {
-	if kv.Properties != nil {
-		return util.Deref(kv.Properties.PublicNetworkAccess) == "Enabled"
+	if kv.Properties != nil && util.Deref(kv.Properties.PublicNetworkAccess) == "Enabled" {
+		if len(kv.Properties.NetworkACLs.VirtualNetworkRules) == 0 && len(kv.Properties.NetworkACLs.IPRules) == 0 {
+			return true
+		} else { // There is at least one rule, i.e. we assume that public network access is restricted
+			return false
+		}
 	}
-
+	// Otherwise, public network access is set to "Disabled" or properties is not set -> we assume no access
 	return false
 }
 

--- a/service/discovery/azure/key_vault.go
+++ b/service/discovery/azure/key_vault.go
@@ -260,16 +260,16 @@ func (d *azureKeyVaultDiscovery) handleKeyVault(kv *armkeyvault.Vault) (*voc.Key
 }
 
 func getPublicAccess(kv *armkeyvault.Vault) bool {
-	// Key Vault is set to "enabled"
+	// Check if Public Network Access of Key Vault is set to "enabled"
 	if kv.Properties != nil && util.Deref(kv.Properties.PublicNetworkAccess) == "Enabled" {
-		// Check if there is at least one ip rule or selected network and default action is deny, i.e. we assume that public network access is restricted
-		if kv.Properties.NetworkACLs != nil && util.Deref(kv.Properties.NetworkACLs.DefaultAction) == armkeyvault.NetworkRuleActionDeny && (len(kv.Properties.NetworkACLs.VirtualNetworkRules) > 0 || len(kv.Properties.NetworkACLs.IPRules) > 0) {
+		// Option 1: It is enabled but there are IP Rules or Virtual Networks defined which have access exclusively (Default action is deny)
+		if kv.Properties.NetworkACLs != nil && util.Deref(kv.Properties.NetworkACLs.DefaultAction) == armkeyvault.NetworkRuleActionDeny && (len(kv.Properties.NetworkACLs.IPRules) > 0 || len(kv.Properties.NetworkACLs.VirtualNetworkRules) > 0) {
 			return false
-		} else { // Otherwise the key vault is public accessible
+		} else { // Option 2: Key vault is public accessible without restrictions
 			return true
 		}
 	}
-	// Otherwise, public network access is set to "Disabled" or properties is not set -> we assume no access
+	// Public network access is set to "Disabled" or properties is not set -> we assume no access
 	return false
 }
 

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -181,6 +181,7 @@ func (d *azureStorageDiscovery) handleCosmosDB(account *armcosmos.DatabaseAccoun
 		publicNetworkAccess = false
 	)
 
+	// TODO(lebogg): Initialization can be removed here, it is done in discoverCosmosDBs - or vice versa.
 	// initialize Cosmos DB client
 	if err = d.initCosmosDBClient(); err != nil {
 		return nil, err

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -805,9 +805,17 @@ func (d *azureStorageDiscovery) handleObjectStorage(account *armstorage.Account,
 			// Todo(lebogg): Add tests
 			Redundancy: getStorageAccountRedundancy(account),
 		},
-		ContainerPublicAccess: util.Deref(container.Properties.PublicAccess) != armstorage.PublicAccessNone, // This is not the public network access https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal, but the container public access
+		ContainerPublicAccess: getPublicAccessOfContainer(container.Properties.PublicAccess), // This is not the public network access https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal, but the container public access
 		IsBackup:              isBackup,
 	}, nil
+}
+
+func getPublicAccessOfContainer(publicAccess *armstorage.PublicAccess) bool {
+	pa := util.Deref(publicAccess)
+	if pa == armstorage.PublicAccessNone || pa == armstorage.PublicAccessBlob {
+		return false
+	}
+	return true // publicAccess is PublicAccessContainer
 }
 
 // isBackup checks if container is used as a backup - and metadata.  If so, it is

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -701,7 +701,7 @@ func (d *azureStorageDiscovery) handleStorageAccount(account *armstorage.Account
 
 // TODO(lebogg): Test it. Maybe add more logic to it, depending on test results
 func getPublicAccessOfStorageAccount(acc *armstorage.Account) bool {
-	if acc.Properties != nil && util.Deref(acc.Properties.PublicNetworkAccess) == "Enabled" {
+	if acc.Properties != nil && util.Deref(acc.Properties.PublicNetworkAccess) == "Enabled" && util.Deref(acc.Properties.NetworkRuleSet.DefaultAction) == armstorage.DefaultActionDeny {
 		if len(acc.Properties.NetworkRuleSet.VirtualNetworkRules) == 0 && len(acc.Properties.NetworkRuleSet.IPRules) == 0 {
 			return true
 		} else {

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -174,10 +174,10 @@ func (d *azureStorageDiscovery) discoverCosmosDB() ([]voc.IsCloudResource, error
 
 func (d *azureStorageDiscovery) handleCosmosDB(account *armcosmos.DatabaseAccountGetResults, activityLogging *voc.ActivityLogging, raw string) ([]voc.IsCloudResource, error) {
 	var (
-		atRestEnc           voc.IsAtRestEncryption
-		err                 error
-		list                []voc.IsCloudResource
-		isManagedByUser     bool
+		atRestEnc       voc.IsAtRestEncryption
+		err             error
+		list            []voc.IsCloudResource
+		isManagedByUser bool
 	)
 
 	// initialize Cosmos DB client
@@ -259,6 +259,11 @@ func (d *azureStorageDiscovery) handleCosmosDB(account *armcosmos.DatabaseAccoun
 }
 
 func getPublicAccessOfCosmosDB(account *armcosmos.DatabaseAccountGetResults) bool {
+	if account.Properties.PublicNetworkAccess == nil {
+		log.Warnf("PublicNetworkAccess for CosmosDB '%s' is empty. We assume that it is publicly accessible",
+			util.Deref(account.Name))
+		return true
+	}
 	if util.Deref(account.Properties.PublicNetworkAccess) == armcosmos.PublicNetworkAccessDisabled {
 		return false
 	}
@@ -337,7 +342,7 @@ func (d *azureStorageDiscovery) handleSqlServer(server *armsql.Server) ([]voc.Is
 	dbList, _ = d.getSqlDBs(server)
 
 	// Check if resource is public available
-	if util.Deref(server.Properties.PublicNetworkAccess) == "Enabled" {
+	if util.Deref(server.Properties.PublicNetworkAccess) == armsql.ServerNetworkAccessFlagEnabled {
 		publicNetworkAccess = true
 	}
 

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -668,7 +668,7 @@ func (d *azureStorageDiscovery) handleStorageAccount(account *armstorage.Account
 func getPublicAccessOfStorageAccount(acc *armstorage.Account) bool {
 	// TODO(lebogg): ADd check for default action allow in rule set before (this would include the special case as well, wher public network access is nil
 	// Check if Public Network Access of Storage Account is set to "enabled"
-	if acc.Properties != nil && util.Deref(acc.Properties.PublicNetworkAccess) == "Enabled" {
+	if acc.Properties != nil && util.Deref(acc.Properties.PublicNetworkAccess) == armstorage.PublicNetworkAccessEnabled {
 		// Option 1: It is enabled but there are IP Rules or Virtual Networks defined which have access exclusively (Default action is deny)
 		if acc.Properties.NetworkRuleSet != nil && util.Deref(acc.Properties.NetworkRuleSet.DefaultAction) == armstorage.DefaultActionDeny && (len(acc.Properties.NetworkRuleSet.IPRules) > 0 || len(acc.Properties.NetworkRuleSet.VirtualNetworkRules) > 0) {
 			return false

--- a/service/discovery/azure/storage.go
+++ b/service/discovery/azure/storage.go
@@ -699,8 +699,16 @@ func (d *azureStorageDiscovery) handleStorageAccount(account *armstorage.Account
 	return storageService, nil
 }
 
+// TODO(lebogg): Test it. Maybe add more logic to it, depending on test results
 func getPublicAccessOfStorageAccount(acc *armstorage.Account) bool {
-	return util.Deref(acc.Properties.PublicNetworkAccess) == "Enabled"
+	if acc.Properties != nil && util.Deref(acc.Properties.PublicNetworkAccess) == "Enabled" {
+		if len(acc.Properties.NetworkRuleSet.VirtualNetworkRules) == 0 && len(acc.Properties.NetworkRuleSet.IPRules) == 0 {
+			return true
+		} else {
+			return false
+		}
+	}
+	return false
 }
 
 func (d *azureStorageDiscovery) handleFileStorage(account *armstorage.Account, fileshare *armstorage.FileShareItem, activityLogging *voc.ActivityLogging) (*voc.FileStorage, error) {

--- a/service/discovery/azure/storage_test.go
+++ b/service/discovery/azure/storage_test.go
@@ -323,7 +323,7 @@ func (m mockStorageSender) Do(req *http.Request) (res *http.Response, err error)
 					"name":     "SQLServer1",
 					"location": "eastus",
 					"properties": map[string]interface{}{
-						"publicNetworkAccess": "enabled",
+						"publicNetworkAccess": armsql.ServerNetworkAccessFlagEnabled,
 					},
 				},
 			},
@@ -944,6 +944,7 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 					},
 				},
 				&voc.DatabaseService{
+					PublicAccess: true,
 					StorageService: &voc.StorageService{
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
@@ -958,7 +959,7 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 									},
 									Labels: make(map[string]string),
 									Parent: voc.ResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1"),
-									Raw:    "{\"*armsql.Server\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1\",\"location\":\"eastus\",\"name\":\"SQLServer1\",\"properties\":{\"publicNetworkAccess\":\"enabled\"}}]}",
+									Raw:    "{\"*armsql.Server\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res1/providers/Microsoft.Sql/servers/SQLServer1\",\"location\":\"eastus\",\"name\":\"SQLServer1\",\"properties\":{\"publicNetworkAccess\":\"Enabled\"}}]}",
 								},
 							},
 							TransportEncryption: &voc.TransportEncryption{
@@ -992,6 +993,7 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 				},
 
 				&voc.DatabaseService{
+					PublicAccess: true, // Should change mockStorageSender to provide something useful (not just nil)
 					StorageService: &voc.StorageService{
 						EncryptionManagedByUser: true,
 						NetworkService: &voc.NetworkService{
@@ -1024,6 +1026,7 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 					},
 				},
 				&voc.DatabaseService{
+					PublicAccess: true, // Should change mockStorageSender to provide something useful (not just nil)
 					StorageService: &voc.StorageService{
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
@@ -2325,6 +2328,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 			},
 			want: []voc.IsCloudResource{
 				&voc.DatabaseService{
+					PublicAccess: true, // Should change mockStorageSender to provide something useful (not just nil)
 					StorageService: &voc.StorageService{
 						EncryptionManagedByUser: true,
 						NetworkService: &voc.NetworkService{
@@ -2357,6 +2361,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 					},
 				},
 				&voc.DatabaseService{
+					PublicAccess: true, // Should change mockStorageSender to provide something useful (not just nil)
 					StorageService: &voc.StorageService{
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
@@ -2450,6 +2455,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []voc.IsCloudResource{
 				&voc.DatabaseService{
+					PublicAccess: true, // Should change mockStorageSender to provide something useful (not just nil)
 					StorageService: &voc.StorageService{
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
@@ -2512,6 +2518,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			},
 			want: []voc.IsCloudResource{
 				&voc.DatabaseService{
+					PublicAccess: true, // Should change mockStorageSender to provide something useful (not just nil)
 					StorageService: &voc.StorageService{
 						EncryptionManagedByUser: true,
 						NetworkService: &voc.NetworkService{


### PR DESCRIPTION
Fix:

- [x] Discovery slots (they have their own API endpoints)
- [x] Container access (besides "None", we now  check "Blob" as well)
- [x] Improve cosmos DB public network check
- [x] Improve key vault public network check