### PR TITLE
Extend discovery: Fix byok

### DIFF
--- a/service/discovery/azure/storage_test.go
+++ b/service/discovery/azure/storage_test.go
@@ -883,6 +883,7 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 				},
 				&voc.ObjectStorageService{
 					StorageService: &voc.StorageService{
+						EncryptionManagedByUser: true,
 						Storage: []voc.ResourceID{
 							"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account2/blobservices/default/containers/container3",
 							"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/res1/providers/microsoft.storage/storageaccounts/account2/blobservices/default/containers/container4",
@@ -992,6 +993,7 @@ func Test_azureStorageDiscovery_List(t *testing.T) {
 
 				&voc.DatabaseService{
 					StorageService: &voc.StorageService{
+						EncryptionManagedByUser: true,
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
 								Resource: &voc.Resource{
@@ -2324,6 +2326,7 @@ func Test_azureStorageDiscovery_discoverCosmosDB(t *testing.T) {
 			want: []voc.IsCloudResource{
 				&voc.DatabaseService{
 					StorageService: &voc.StorageService{
+						EncryptionManagedByUser: true,
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
 								Resource: &voc.Resource{
@@ -2510,6 +2513,7 @@ func Test_azureStorageDiscovery_handleCosmosDB(t *testing.T) {
 			want: []voc.IsCloudResource{
 				&voc.DatabaseService{
 					StorageService: &voc.StorageService{
+						EncryptionManagedByUser: true,
 						NetworkService: &voc.NetworkService{
 							Networking: &voc.Networking{
 								Resource: &voc.Resource{

--- a/voc/storage_service.go
+++ b/voc/storage_service.go
@@ -32,7 +32,8 @@ var StorageServiceType = []string{"StorageService", "NetworkService", "Networkin
 // StorageService is an entity in our Cloud ontology. This entity represents a network-based service that can be used to access a particular storage backend. It has multiple subclasses, e.g., for databases or object stores. It has a list of storage resources associated to it.
 type StorageService struct {
 	*NetworkService
-	Redundancy      *Redundancy      `json:"redundancy"`
-	Storage         []ResourceID     `json:"storage"`
-	ActivityLogging *ActivityLogging `json:"activityLogging"`
+	Redundancy              *Redundancy      `json:"redundancy"`
+	Storage                 []ResourceID     `json:"storage"`
+	ActivityLogging         *ActivityLogging `json:"activityLogging"`
+	EncryptionManagedByUser bool             `json:"encryptionManagedByUser"`
 }


### PR DESCRIPTION
We didn't have the possibility to set encryption for entire storage services (e.g. Storage Account or Cosmos DB). Because it doesn't support AtRestEncryption. As a hotfix, I added a `encryptionManagedByUser` field to the voc file and use it in `handleStorageAccount` and `handleCosmosDB`