### PR TITLE
Update func for the public network access status

### DIFF
--- a/service/discovery/azure/azure_properties.go
+++ b/service/discovery/azure/azure_properties.go
@@ -260,3 +260,18 @@ func location(region *string) *ontology.GeoLocation {
 		Region: util.Deref(region),
 	}
 }
+
+// publicNetworkAccessStatus returns the public access status of the resource
+func publicNetworkAccessStatus(status *string) bool {
+	// Check if a mandatory field is empty
+	if status == nil {
+		return false
+	}
+
+	// Check if resource is public available
+	if util.Deref(status) == "Enabled" {
+		return true
+	}
+
+	return false
+}

--- a/service/discovery/azure/compute_handle.go
+++ b/service/discovery/azure/compute_handle.go
@@ -224,7 +224,7 @@ func (d *azureDiscovery) handleFunction(function *armappservice.Site, config arm
 		/*HttpEndpoint: &ontology.HttpEndpoint{
 			TransportEncryption: getTransportEncryption(function.Properties, config),
 		},*/
-		InternetAccessibleEndpoint: getInternetAccessibleEndpoint(function),
+		InternetAccessibleEndpoint: publicNetworkAccessStatus(function.Properties.PublicNetworkAccess),
 		Redundancies:               getRedundancies(function),
 	}
 }
@@ -251,7 +251,7 @@ func (d *azureDiscovery) handleWebApp(webApp *armappservice.Site, config armapps
 		/*HttpEndpoint: &ontology.HttpEndpoint{
 			TransportEncryption: getTransportEncryption(webApp.Properties, config),
 		},*/
-		InternetAccessibleEndpoint: getInternetAccessibleEndpoint(webApp),
+		InternetAccessibleEndpoint: publicNetworkAccessStatus(webApp.Properties.PublicNetworkAccess),
 		Redundancies:               getRedundancies(webApp),
 	}
 }

--- a/service/discovery/azure/compute_properties.go
+++ b/service/discovery/azure/compute_properties.go
@@ -140,21 +140,6 @@ func getVirtualNetworkSubnetId(site *armappservice.Site) []string {
 	return ni
 }
 
-// getInternetAccessibleEndpoint returns the public access status for webApp and function
-func getInternetAccessibleEndpoint(site *armappservice.Site) bool {
-	// Check if a mandatory field is empty
-	if site == nil {
-		return false
-	}
-
-	// Check if resource is public available
-	if util.Deref(site.Properties.PublicNetworkAccess) == "Enabled" {
-		return true
-	}
-
-	return false
-}
-
 // getResourceLoggingWebApps determines if logging is activated for given web app or function by checking the respective app setting
 func (d *azureDiscovery) getResourceLoggingWebApps(site *armappservice.Site) (rl *ontology.ResourceLogging) {
 	rl = &ontology.ResourceLogging{}

--- a/service/discovery/azure/compute_test.go
+++ b/service/discovery/azure/compute_test.go
@@ -1834,9 +1834,9 @@ func Test_getRedundancies(t *testing.T) {
 	}
 }
 
-func Test_getInternetAccessibleEndpoint(t *testing.T) {
+func Test_publicNetworkAccessStatus(t *testing.T) {
 	type args struct {
-		site *armappservice.Site
+		status *string
 	}
 	tests := []struct {
 		name string
@@ -1851,30 +1851,22 @@ func Test_getInternetAccessibleEndpoint(t *testing.T) {
 		{
 			name: "Happy path: Enabled",
 			args: args{
-				site: &armappservice.Site{
-					Properties: &armappservice.SiteProperties{
-						PublicNetworkAccess: util.Ref("Enabled"),
-					},
-				},
+				status: util.Ref("Enabled"),
 			},
 			want: true,
 		},
 		{
 			name: "Happy path: Empty String",
 			args: args{
-				site: &armappservice.Site{
-					Properties: &armappservice.SiteProperties{
-						PublicNetworkAccess: util.Ref(""),
-					},
-				},
+				status: util.Ref(""),
 			},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getInternetAccessibleEndpoint(tt.args.site); got != tt.want {
-				t.Errorf("getInternetAccessibleEndpoint() = %v, want %v", got, tt.want)
+			if got := publicNetworkAccessStatus(tt.args.status); got != tt.want {
+				t.Errorf("publicNetworkAccessStatus() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR modifies the function for retrieving the public network access status. Previously, the function was limited to WebApp resources; now, it can be utilized by all resource types to obtain the status.