### PR TITLE
Revert "Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts clouditor/clouditor#1372

We should avoid updating to version 5,as it appears to be unstable.