### PR TITLE
Add launcher check for storage creation

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -76,15 +76,16 @@ func NewLauncher(name string, specs ...ServiceSpec) (l *Launcher, err error) {
 	}
 
 	// Set storage
-	err = l.initStorage()
-	if err != nil {
-		return nil, err
+	if l.name != "assessment" {
+		err = l.initStorage()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create the services out of the service specs
 	for _, spec := range specs {
 		// Create the service and gather the gRPC server options
-
 		svc, grpcOpts, err := spec.NewService(l.db)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR adds a check for the used launcher. If the launcher assessment is used, no storage creation is necessary as the assessment does not store anything to the DB.