### PR TITLE
Fixes of renaming `CertificationTarget` to `TargetOfEvaluation`

### DIFF
--- a/cli/commands/cloud/cloud.go
+++ b/cli/commands/cloud/cloud.go
@@ -42,7 +42,7 @@ import (
 func NewCreateTargetOfEvaluationCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "register [name]",
-		Short: "Registers a new target target of evaluation",
+		Short: "Registers a new target of evaluation",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
@@ -81,7 +81,7 @@ func NewCreateTargetOfEvaluationCommand() *cobra.Command {
 func NewListTargetsOfEvaluationCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists all target target of evaluations",
+		Short: "Lists all target of evaluations",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				err     error
@@ -121,7 +121,7 @@ func NewListTargetsOfEvaluationCommand() *cobra.Command {
 func NewGetTargetOfEvaluationCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get [id]",
-		Short: "Retrieves a target target of evaluation by its ID",
+		Short: "Retrieves a target of evaluation by its ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
@@ -154,7 +154,7 @@ func NewGetTargetOfEvaluationCommand() *cobra.Command {
 func NewRemoveTargetOfEvaluationComand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove [id]",
-		Short: "Removes a target target of evaluation by its ID",
+		Short: "Removes a target of evaluation by its ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
@@ -187,7 +187,7 @@ func NewRemoveTargetOfEvaluationComand() *cobra.Command {
 func NewUpdateTargetOfEvaluationCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Updates a target target of evaluation",
+		Short: "Updates a target of evaluation",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				err     error

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -121,7 +121,7 @@ func LogRequest(log *logrus.Entry, level logrus.Level, reqType RequestType, req 
 	}
 
 	// Check, if it is a target of evaluation request. In this case we can append the
-	// information about the target target of evaluation. However, we only want to do
+	// information about the target of evaluation. However, we only want to do
 	// that, if the payload type is not a target of evaluation itself.
 	ctreq, ok := req.(api.TargetOfEvaluationRequest)
 	if name != "TargetOfEvaluation" && ok {

--- a/server/commands/orchestrator/orchestrator.go
+++ b/server/commands/orchestrator/orchestrator.go
@@ -57,10 +57,10 @@ func NewOrchestratorCommand() *cobra.Command {
 }
 
 func BindFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(config.CreateDefaultTargetOfEvaluationFlag, config.DefaultCreateDefaultTarget, "Creates a default target target of evaluation if it does not exist")
-	cmd.Flags().String(config.DefaultTargetOfEvaluationNameFlag, config.DefaultTargetOfEvaluationName, "Name of the default target target of evaluation")
-	cmd.Flags().String(config.DefaultTargetOfEvaluationDescriptionFlag, config.DefaultTargetOfEvaluationDescription, "Description of the default target target of evaluation")
-	cmd.Flags().Int32(config.DefaultTargetOfEvaluationTypeFlag, int32(config.DefaultTargetOfEvaluationType), "Type of the default target target of evaluation; (1=cloud, 2=product, 3=organisation)")
+	cmd.Flags().Bool(config.CreateDefaultTargetOfEvaluationFlag, config.DefaultCreateDefaultTarget, "Creates a default target of evaluation if it does not exist")
+	cmd.Flags().String(config.DefaultTargetOfEvaluationNameFlag, config.DefaultTargetOfEvaluationName, "Name of the default target of evaluation")
+	cmd.Flags().String(config.DefaultTargetOfEvaluationDescriptionFlag, config.DefaultTargetOfEvaluationDescription, "Description of the default target of evaluation")
+	cmd.Flags().Int32(config.DefaultTargetOfEvaluationTypeFlag, int32(config.DefaultTargetOfEvaluationType), "Type of the default target of evaluation; (1=cloud, 2=product, 3=organisation)")
 	if cmd.Flag(config.APIgRPCPortFlag) == nil {
 		cmd.Flags().Uint16(config.APIgRPCPortFlag, config.DefaultAPIgRPCPortOrchestrator, "Specifies the port used for the Clouditor gRPC API")
 	}

--- a/service/assessment/assessment.go
+++ b/service/assessment/assessment.go
@@ -598,7 +598,7 @@ func (svc *Service) MetricImplementation(lang assessment.MetricImplementation_La
 }
 
 // MetricConfiguration implements MetricsSource by getting the corresponding metric configuration for the
-// default target target of evaluation
+// default target of evaluation
 func (svc *Service) MetricConfiguration(TargetOfEvaluationID string, metric *assessment.Metric) (config *assessment.MetricConfiguration, err error) {
 	var (
 		ok    bool

--- a/service/orchestrator/orchestrator.go
+++ b/service/orchestrator/orchestrator.go
@@ -72,7 +72,7 @@ func DefaultServiceSpec() launcher.ServiceSpec {
 			if viper.GetBool(config.CreateDefaultTargetOfEvaluationFlag) {
 				_, err := svc.CreateDefaultTargetOfEvaluation()
 				if err != nil {
-					return nil, fmt.Errorf("could not register default target target of evaluation: %v", err)
+					return nil, fmt.Errorf("could not register default target of evaluation: %v", err)
 				}
 			}
 

--- a/service/orchestrator/target_of_evaluation.go
+++ b/service/orchestrator/target_of_evaluation.go
@@ -304,10 +304,10 @@ func (s *Service) CreateDefaultTargetOfEvaluation() (target *orchestrator.Target
 		if err != nil {
 			return nil, fmt.Errorf("storage error: %w", err)
 		} else {
-			log.Infof("Created new default target target of evaluation: %s", target.Id)
+			log.Infof("Created new default target of evaluation: %s", target.Id)
 		}
 	} else {
-		log.Infof("Default target target of evaluation already exist.")
+		log.Infof("Default target of evaluation already exist.")
 	}
 
 	return


### PR DESCRIPTION
This PR fixes upcoming naming issues after merging PR #1673 .