### PR TITLE
Remove duplicated google.api.field_behaviour

### DIFF
--- a/api/orchestrator/orchestrator.pb.go
+++ b/api/orchestrator/orchestrator.pb.go
@@ -4482,9 +4482,9 @@ const file_api_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\n" +
 	"page_token\x18\v \x01(\tR\tpageToken\x12\x19\n" +
 	"\border_by\x18\f \x01(\tR\aorderBy\x12\x10\n" +
-	"\x03asc\x18\r \x01(\bR\x03asc\"\x9a\x01\n" +
-	"\x1fListTargetsOfEvaluationResponse\x12O\n" +
-	"\atargets\x18\x01 \x03(\v2-.clouditor.orchestrator.v1.TargetOfEvaluationB\x06\xe0A\x02\xe0A\x02R\atargets\x12&\n" +
+	"\x03asc\x18\r \x01(\bR\x03asc\"\x97\x01\n" +
+	"\x1fListTargetsOfEvaluationResponse\x12L\n" +
+	"\atargets\x18\x01 \x03(\v2-.clouditor.orchestrator.v1.TargetOfEvaluationB\x03\xe0A\x02R\atargets\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"l\n" +
 	"&GetTargetOfEvaluationStatisticsRequest\x12B\n" +
 	"\x17target_of_evaluation_id\x18\x01 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x14targetOfEvaluationId\"\x9e\x02\n" +

--- a/api/orchestrator/orchestrator.proto
+++ b/api/orchestrator/orchestrator.proto
@@ -492,10 +492,7 @@ message ListTargetsOfEvaluationRequest {
 }
 
 message ListTargetsOfEvaluationResponse {
-  repeated TargetOfEvaluation targets = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.field_behavior) = REQUIRED
-  ];
+  repeated TargetOfEvaluation targets = 1 [(google.api.field_behavior) = REQUIRED];
   string next_page_token = 2;
 }
 

--- a/openapi/orchestrator/openapi.yaml
+++ b/openapi/orchestrator/openapi.yaml
@@ -1952,7 +1952,6 @@ components:
         ListTargetsOfEvaluationResponse:
             required:
                 - targets
-                - targets
             type: object
             properties:
                 targets:


### PR DESCRIPTION
This PR removes the duplicated field `google.api.field_behavior) = REQUIRED` in ListTargetsOfEvaluationResponse.