### PR TITLE
evidenceStore: Add endpoint 'ListSupportedResourceTypes'

### DIFF
--- a/api/assessment/assessment.pb.gw.go
+++ b/api/assessment/assessment.pb.gw.go
@@ -43,6 +43,9 @@ func request_Assessment_AssessEvidence_0(ctx context.Context, marshaler runtime.
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Evidence); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.AssessEvidence(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }

--- a/api/discovery/discovery.pb.gw.go
+++ b/api/discovery/discovery.pb.gw.go
@@ -43,6 +43,9 @@ func request_Discovery_Start_0(ctx context.Context, marshaler runtime.Marshaler,
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.Start(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -66,7 +69,9 @@ func request_Discovery_ListResources_0(ctx context.Context, marshaler runtime.Ma
 		protoReq ListResourcesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/api/discovery/experimental.pb.gw.go
+++ b/api/discovery/experimental.pb.gw.go
@@ -44,6 +44,9 @@ func request_ExperimentalDiscovery_UpdateResource_0(ctx context.Context, marshal
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["resource.id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "resource.id")
@@ -84,7 +87,9 @@ func request_ExperimentalDiscovery_ListGraphEdges_0(ctx context.Context, marshal
 		protoReq ListGraphEdgesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/api/evaluation/evaluation.pb.gw.go
+++ b/api/evaluation/evaluation.pb.gw.go
@@ -43,7 +43,9 @@ func request_Evaluation_StartEvaluation_0(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["audit_scope_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "audit_scope_id")
@@ -92,7 +94,9 @@ func request_Evaluation_StopEvaluation_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["audit_scope_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "audit_scope_id")
@@ -130,7 +134,9 @@ func request_Evaluation_ListEvaluationResults_0(ctx context.Context, marshaler r
 		protoReq ListEvaluationResultsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -163,6 +169,9 @@ func request_Evaluation_CreateEvaluationResult_0(ctx context.Context, marshaler 
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Result); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	msg, err := client.CreateEvaluationResult(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err

--- a/api/evidence/evidence_store.pb.go
+++ b/api/evidence/evidence_store.pb.go
@@ -465,6 +465,86 @@ func (x *GetEvidenceRequest) GetEvidenceId() string {
 	return ""
 }
 
+type GetSupportedResourceTypesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSupportedResourceTypesRequest) Reset() {
+	*x = GetSupportedResourceTypesRequest{}
+	mi := &file_api_evidence_evidence_store_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSupportedResourceTypesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSupportedResourceTypesRequest) ProtoMessage() {}
+
+func (x *GetSupportedResourceTypesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_evidence_evidence_store_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSupportedResourceTypesRequest.ProtoReflect.Descriptor instead.
+func (*GetSupportedResourceTypesRequest) Descriptor() ([]byte, []int) {
+	return file_api_evidence_evidence_store_proto_rawDescGZIP(), []int{7}
+}
+
+type GetSupportedResourceTypesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ResourceTypes []string               `protobuf:"bytes,1,rep,name=resource_types,json=resourceTypes,proto3" json:"resource_types,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSupportedResourceTypesResponse) Reset() {
+	*x = GetSupportedResourceTypesResponse{}
+	mi := &file_api_evidence_evidence_store_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSupportedResourceTypesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSupportedResourceTypesResponse) ProtoMessage() {}
+
+func (x *GetSupportedResourceTypesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_evidence_evidence_store_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSupportedResourceTypesResponse.ProtoReflect.Descriptor instead.
+func (*GetSupportedResourceTypesResponse) Descriptor() ([]byte, []int) {
+	return file_api_evidence_evidence_store_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GetSupportedResourceTypesResponse) GetResourceTypes() []string {
+	if x != nil {
+		return x.ResourceTypes
+	}
+	return nil
+}
+
 var File_api_evidence_evidence_store_proto protoreflect.FileDescriptor
 
 const file_api_evidence_evidence_store_proto_rawDesc = "" +
@@ -497,16 +577,20 @@ const file_api_evidence_evidence_store_proto_rawDesc = "" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"?\n" +
 	"\x12GetEvidenceRequest\x12)\n" +
 	"\vevidence_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\n" +
-	"evidenceId*d\n" +
+	"evidenceId\"\"\n" +
+	" GetSupportedResourceTypesRequest\"T\n" +
+	"!GetSupportedResourceTypesResponse\x12/\n" +
+	"\x0eresource_types\x18\x01 \x03(\tB\b\xbaH\x05\x92\x01\x02\b\x01R\rresourceTypes*d\n" +
 	"\x0eEvidenceStatus\x12\x1f\n" +
 	"\x1bEVIDENCE_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12EVIDENCE_STATUS_OK\x10\x01\x12\x19\n" +
-	"\x15EVIDENCE_STATUS_ERROR\x10\x022\xc2\x04\n" +
+	"\x15EVIDENCE_STATUS_ERROR\x10\x022\x88\x06\n" +
 	"\rEvidenceStore\x12\x99\x01\n" +
 	"\rStoreEvidence\x12+.clouditor.evidence.v1.StoreEvidenceRequest\x1a,.clouditor.evidence.v1.StoreEvidenceResponse\"-\x82\xd3\xe4\x93\x02':\bevidence\"\x1b/v1/evidence_store/evidence\x12r\n" +
 	"\x0eStoreEvidences\x12+.clouditor.evidence.v1.StoreEvidenceRequest\x1a-.clouditor.evidence.v1.StoreEvidencesResponse\"\x00(\x010\x01\x12\x90\x01\n" +
 	"\rListEvidences\x12+.clouditor.evidence.v1.ListEvidencesRequest\x1a,.clouditor.evidence.v1.ListEvidencesResponse\"$\x82\xd3\xe4\x93\x02\x1e\x12\x1c/v1/evidence_store/evidences\x12\x8d\x01\n" +
-	"\vGetEvidence\x12).clouditor.evidence.v1.GetEvidenceRequest\x1a\x1f.clouditor.evidence.v1.Evidence\"2\x82\xd3\xe4\x93\x02,\x12*/v1/evidence_store/evidences/{evidence_id}B(Z&clouditor.io/clouditor/v2/api/evidenceb\x06proto3"
+	"\vGetEvidence\x12).clouditor.evidence.v1.GetEvidenceRequest\x1a\x1f.clouditor.evidence.v1.Evidence\"2\x82\xd3\xe4\x93\x02,\x12*/v1/evidence_store/evidences/{evidence_id}\x12\xc3\x01\n" +
+	"\x19GetSupportedResourceTypes\x127.clouditor.evidence.v1.GetSupportedResourceTypesRequest\x1a8.clouditor.evidence.v1.GetSupportedResourceTypesResponse\"3\x82\xd3\xe4\x93\x02-\x12+/v1/evidence_store/supported_resource_typesB(Z&clouditor.io/clouditor/v2/api/evidenceb\x06proto3"
 
 var (
 	file_api_evidence_evidence_store_proto_rawDescOnce sync.Once
@@ -521,37 +605,41 @@ func file_api_evidence_evidence_store_proto_rawDescGZIP() []byte {
 }
 
 var file_api_evidence_evidence_store_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_evidence_evidence_store_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_api_evidence_evidence_store_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_api_evidence_evidence_store_proto_goTypes = []any{
-	(EvidenceStatus)(0),            // 0: clouditor.evidence.v1.EvidenceStatus
-	(*StoreEvidenceRequest)(nil),   // 1: clouditor.evidence.v1.StoreEvidenceRequest
-	(*StoreEvidenceResponse)(nil),  // 2: clouditor.evidence.v1.StoreEvidenceResponse
-	(*StoreEvidencesResponse)(nil), // 3: clouditor.evidence.v1.StoreEvidencesResponse
-	(*ListEvidencesRequest)(nil),   // 4: clouditor.evidence.v1.ListEvidencesRequest
-	(*Filter)(nil),                 // 5: clouditor.evidence.v1.Filter
-	(*ListEvidencesResponse)(nil),  // 6: clouditor.evidence.v1.ListEvidencesResponse
-	(*GetEvidenceRequest)(nil),     // 7: clouditor.evidence.v1.GetEvidenceRequest
-	(*Evidence)(nil),               // 8: clouditor.evidence.v1.Evidence
+	(EvidenceStatus)(0),                       // 0: clouditor.evidence.v1.EvidenceStatus
+	(*StoreEvidenceRequest)(nil),              // 1: clouditor.evidence.v1.StoreEvidenceRequest
+	(*StoreEvidenceResponse)(nil),             // 2: clouditor.evidence.v1.StoreEvidenceResponse
+	(*StoreEvidencesResponse)(nil),            // 3: clouditor.evidence.v1.StoreEvidencesResponse
+	(*ListEvidencesRequest)(nil),              // 4: clouditor.evidence.v1.ListEvidencesRequest
+	(*Filter)(nil),                            // 5: clouditor.evidence.v1.Filter
+	(*ListEvidencesResponse)(nil),             // 6: clouditor.evidence.v1.ListEvidencesResponse
+	(*GetEvidenceRequest)(nil),                // 7: clouditor.evidence.v1.GetEvidenceRequest
+	(*GetSupportedResourceTypesRequest)(nil),  // 8: clouditor.evidence.v1.GetSupportedResourceTypesRequest
+	(*GetSupportedResourceTypesResponse)(nil), // 9: clouditor.evidence.v1.GetSupportedResourceTypesResponse
+	(*Evidence)(nil),                          // 10: clouditor.evidence.v1.Evidence
 }
 var file_api_evidence_evidence_store_proto_depIdxs = []int32{
-	8, // 0: clouditor.evidence.v1.StoreEvidenceRequest.evidence:type_name -> clouditor.evidence.v1.Evidence
-	0, // 1: clouditor.evidence.v1.StoreEvidenceResponse.status:type_name -> clouditor.evidence.v1.EvidenceStatus
-	0, // 2: clouditor.evidence.v1.StoreEvidencesResponse.status:type_name -> clouditor.evidence.v1.EvidenceStatus
-	5, // 3: clouditor.evidence.v1.ListEvidencesRequest.filter:type_name -> clouditor.evidence.v1.Filter
-	8, // 4: clouditor.evidence.v1.ListEvidencesResponse.evidences:type_name -> clouditor.evidence.v1.Evidence
-	1, // 5: clouditor.evidence.v1.EvidenceStore.StoreEvidence:input_type -> clouditor.evidence.v1.StoreEvidenceRequest
-	1, // 6: clouditor.evidence.v1.EvidenceStore.StoreEvidences:input_type -> clouditor.evidence.v1.StoreEvidenceRequest
-	4, // 7: clouditor.evidence.v1.EvidenceStore.ListEvidences:input_type -> clouditor.evidence.v1.ListEvidencesRequest
-	7, // 8: clouditor.evidence.v1.EvidenceStore.GetEvidence:input_type -> clouditor.evidence.v1.GetEvidenceRequest
-	2, // 9: clouditor.evidence.v1.EvidenceStore.StoreEvidence:output_type -> clouditor.evidence.v1.StoreEvidenceResponse
-	3, // 10: clouditor.evidence.v1.EvidenceStore.StoreEvidences:output_type -> clouditor.evidence.v1.StoreEvidencesResponse
-	6, // 11: clouditor.evidence.v1.EvidenceStore.ListEvidences:output_type -> clouditor.evidence.v1.ListEvidencesResponse
-	8, // 12: clouditor.evidence.v1.EvidenceStore.GetEvidence:output_type -> clouditor.evidence.v1.Evidence
-	9, // [9:13] is the sub-list for method output_type
-	5, // [5:9] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	10, // 0: clouditor.evidence.v1.StoreEvidenceRequest.evidence:type_name -> clouditor.evidence.v1.Evidence
+	0,  // 1: clouditor.evidence.v1.StoreEvidenceResponse.status:type_name -> clouditor.evidence.v1.EvidenceStatus
+	0,  // 2: clouditor.evidence.v1.StoreEvidencesResponse.status:type_name -> clouditor.evidence.v1.EvidenceStatus
+	5,  // 3: clouditor.evidence.v1.ListEvidencesRequest.filter:type_name -> clouditor.evidence.v1.Filter
+	10, // 4: clouditor.evidence.v1.ListEvidencesResponse.evidences:type_name -> clouditor.evidence.v1.Evidence
+	1,  // 5: clouditor.evidence.v1.EvidenceStore.StoreEvidence:input_type -> clouditor.evidence.v1.StoreEvidenceRequest
+	1,  // 6: clouditor.evidence.v1.EvidenceStore.StoreEvidences:input_type -> clouditor.evidence.v1.StoreEvidenceRequest
+	4,  // 7: clouditor.evidence.v1.EvidenceStore.ListEvidences:input_type -> clouditor.evidence.v1.ListEvidencesRequest
+	7,  // 8: clouditor.evidence.v1.EvidenceStore.GetEvidence:input_type -> clouditor.evidence.v1.GetEvidenceRequest
+	8,  // 9: clouditor.evidence.v1.EvidenceStore.GetSupportedResourceTypes:input_type -> clouditor.evidence.v1.GetSupportedResourceTypesRequest
+	2,  // 10: clouditor.evidence.v1.EvidenceStore.StoreEvidence:output_type -> clouditor.evidence.v1.StoreEvidenceResponse
+	3,  // 11: clouditor.evidence.v1.EvidenceStore.StoreEvidences:output_type -> clouditor.evidence.v1.StoreEvidencesResponse
+	6,  // 12: clouditor.evidence.v1.EvidenceStore.ListEvidences:output_type -> clouditor.evidence.v1.ListEvidencesResponse
+	10, // 13: clouditor.evidence.v1.EvidenceStore.GetEvidence:output_type -> clouditor.evidence.v1.Evidence
+	9,  // 14: clouditor.evidence.v1.EvidenceStore.GetSupportedResourceTypes:output_type -> clouditor.evidence.v1.GetSupportedResourceTypesResponse
+	10, // [10:15] is the sub-list for method output_type
+	5,  // [5:10] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_api_evidence_evidence_store_proto_init() }
@@ -568,7 +656,7 @@ func file_api_evidence_evidence_store_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_evidence_evidence_store_proto_rawDesc), len(file_api_evidence_evidence_store_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/evidence/evidence_store.pb.go
+++ b/api/evidence/evidence_store.pb.go
@@ -503,7 +503,7 @@ func (*GetSupportedResourceTypesRequest) Descriptor() ([]byte, []int) {
 
 type GetSupportedResourceTypesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ResourceTypes []string               `protobuf:"bytes,1,rep,name=resource_types,json=resourceTypes,proto3" json:"resource_types,omitempty"`
+	ResourceType  []string               `protobuf:"bytes,1,rep,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -538,9 +538,9 @@ func (*GetSupportedResourceTypesResponse) Descriptor() ([]byte, []int) {
 	return file_api_evidence_evidence_store_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *GetSupportedResourceTypesResponse) GetResourceTypes() []string {
+func (x *GetSupportedResourceTypesResponse) GetResourceType() []string {
 	if x != nil {
-		return x.ResourceTypes
+		return x.ResourceType
 	}
 	return nil
 }
@@ -578,9 +578,9 @@ const file_api_evidence_evidence_store_proto_rawDesc = "" +
 	"\x12GetEvidenceRequest\x12)\n" +
 	"\vevidence_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\n" +
 	"evidenceId\"\"\n" +
-	" GetSupportedResourceTypesRequest\"T\n" +
-	"!GetSupportedResourceTypesResponse\x12/\n" +
-	"\x0eresource_types\x18\x01 \x03(\tB\b\xbaH\x05\x92\x01\x02\b\x01R\rresourceTypes*d\n" +
+	" GetSupportedResourceTypesRequest\"R\n" +
+	"!GetSupportedResourceTypesResponse\x12-\n" +
+	"\rresource_type\x18\x01 \x03(\tB\b\xbaH\x05\x92\x01\x02\b\x01R\fresourceType*d\n" +
 	"\x0eEvidenceStatus\x12\x1f\n" +
 	"\x1bEVIDENCE_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12EVIDENCE_STATUS_OK\x10\x01\x12\x19\n" +

--- a/api/evidence/evidence_store.pb.go
+++ b/api/evidence/evidence_store.pb.go
@@ -32,13 +32,14 @@
 package evidence
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (
@@ -465,26 +466,26 @@ func (x *GetEvidenceRequest) GetEvidenceId() string {
 	return ""
 }
 
-type GetSupportedResourceTypesRequest struct {
+type ListSupportedResourceTypesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetSupportedResourceTypesRequest) Reset() {
-	*x = GetSupportedResourceTypesRequest{}
+func (x *ListSupportedResourceTypesRequest) Reset() {
+	*x = ListSupportedResourceTypesRequest{}
 	mi := &file_api_evidence_evidence_store_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetSupportedResourceTypesRequest) String() string {
+func (x *ListSupportedResourceTypesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetSupportedResourceTypesRequest) ProtoMessage() {}
+func (*ListSupportedResourceTypesRequest) ProtoMessage() {}
 
-func (x *GetSupportedResourceTypesRequest) ProtoReflect() protoreflect.Message {
+func (x *ListSupportedResourceTypesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_api_evidence_evidence_store_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -496,32 +497,32 @@ func (x *GetSupportedResourceTypesRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetSupportedResourceTypesRequest.ProtoReflect.Descriptor instead.
-func (*GetSupportedResourceTypesRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListSupportedResourceTypesRequest.ProtoReflect.Descriptor instead.
+func (*ListSupportedResourceTypesRequest) Descriptor() ([]byte, []int) {
 	return file_api_evidence_evidence_store_proto_rawDescGZIP(), []int{7}
 }
 
-type GetSupportedResourceTypesResponse struct {
+type ListSupportedResourceTypesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ResourceType  []string               `protobuf:"bytes,1,rep,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetSupportedResourceTypesResponse) Reset() {
-	*x = GetSupportedResourceTypesResponse{}
+func (x *ListSupportedResourceTypesResponse) Reset() {
+	*x = ListSupportedResourceTypesResponse{}
 	mi := &file_api_evidence_evidence_store_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetSupportedResourceTypesResponse) String() string {
+func (x *ListSupportedResourceTypesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetSupportedResourceTypesResponse) ProtoMessage() {}
+func (*ListSupportedResourceTypesResponse) ProtoMessage() {}
 
-func (x *GetSupportedResourceTypesResponse) ProtoReflect() protoreflect.Message {
+func (x *ListSupportedResourceTypesResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_api_evidence_evidence_store_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -533,12 +534,12 @@ func (x *GetSupportedResourceTypesResponse) ProtoReflect() protoreflect.Message 
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetSupportedResourceTypesResponse.ProtoReflect.Descriptor instead.
-func (*GetSupportedResourceTypesResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListSupportedResourceTypesResponse.ProtoReflect.Descriptor instead.
+func (*ListSupportedResourceTypesResponse) Descriptor() ([]byte, []int) {
 	return file_api_evidence_evidence_store_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *GetSupportedResourceTypesResponse) GetResourceType() []string {
+func (x *ListSupportedResourceTypesResponse) GetResourceType() []string {
 	if x != nil {
 		return x.ResourceType
 	}
@@ -577,20 +578,20 @@ const file_api_evidence_evidence_store_proto_rawDesc = "" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"?\n" +
 	"\x12GetEvidenceRequest\x12)\n" +
 	"\vevidence_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\n" +
-	"evidenceId\"\"\n" +
-	" GetSupportedResourceTypesRequest\"R\n" +
-	"!GetSupportedResourceTypesResponse\x12-\n" +
+	"evidenceId\"#\n" +
+	"!ListSupportedResourceTypesRequest\"S\n" +
+	"\"ListSupportedResourceTypesResponse\x12-\n" +
 	"\rresource_type\x18\x01 \x03(\tB\b\xbaH\x05\x92\x01\x02\b\x01R\fresourceType*d\n" +
 	"\x0eEvidenceStatus\x12\x1f\n" +
 	"\x1bEVIDENCE_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12EVIDENCE_STATUS_OK\x10\x01\x12\x19\n" +
-	"\x15EVIDENCE_STATUS_ERROR\x10\x022\x88\x06\n" +
+	"\x15EVIDENCE_STATUS_ERROR\x10\x022\x8b\x06\n" +
 	"\rEvidenceStore\x12\x99\x01\n" +
 	"\rStoreEvidence\x12+.clouditor.evidence.v1.StoreEvidenceRequest\x1a,.clouditor.evidence.v1.StoreEvidenceResponse\"-\x82\xd3\xe4\x93\x02':\bevidence\"\x1b/v1/evidence_store/evidence\x12r\n" +
 	"\x0eStoreEvidences\x12+.clouditor.evidence.v1.StoreEvidenceRequest\x1a-.clouditor.evidence.v1.StoreEvidencesResponse\"\x00(\x010\x01\x12\x90\x01\n" +
 	"\rListEvidences\x12+.clouditor.evidence.v1.ListEvidencesRequest\x1a,.clouditor.evidence.v1.ListEvidencesResponse\"$\x82\xd3\xe4\x93\x02\x1e\x12\x1c/v1/evidence_store/evidences\x12\x8d\x01\n" +
-	"\vGetEvidence\x12).clouditor.evidence.v1.GetEvidenceRequest\x1a\x1f.clouditor.evidence.v1.Evidence\"2\x82\xd3\xe4\x93\x02,\x12*/v1/evidence_store/evidences/{evidence_id}\x12\xc3\x01\n" +
-	"\x19GetSupportedResourceTypes\x127.clouditor.evidence.v1.GetSupportedResourceTypesRequest\x1a8.clouditor.evidence.v1.GetSupportedResourceTypesResponse\"3\x82\xd3\xe4\x93\x02-\x12+/v1/evidence_store/supported_resource_typesB(Z&clouditor.io/clouditor/v2/api/evidenceb\x06proto3"
+	"\vGetEvidence\x12).clouditor.evidence.v1.GetEvidenceRequest\x1a\x1f.clouditor.evidence.v1.Evidence\"2\x82\xd3\xe4\x93\x02,\x12*/v1/evidence_store/evidences/{evidence_id}\x12\xc6\x01\n" +
+	"\x1aListSupportedResourceTypes\x128.clouditor.evidence.v1.ListSupportedResourceTypesRequest\x1a9.clouditor.evidence.v1.ListSupportedResourceTypesResponse\"3\x82\xd3\xe4\x93\x02-\x12+/v1/evidence_store/supported_resource_typesB(Z&clouditor.io/clouditor/v2/api/evidenceb\x06proto3"
 
 var (
 	file_api_evidence_evidence_store_proto_rawDescOnce sync.Once
@@ -607,17 +608,17 @@ func file_api_evidence_evidence_store_proto_rawDescGZIP() []byte {
 var file_api_evidence_evidence_store_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_api_evidence_evidence_store_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_api_evidence_evidence_store_proto_goTypes = []any{
-	(EvidenceStatus)(0),                       // 0: clouditor.evidence.v1.EvidenceStatus
-	(*StoreEvidenceRequest)(nil),              // 1: clouditor.evidence.v1.StoreEvidenceRequest
-	(*StoreEvidenceResponse)(nil),             // 2: clouditor.evidence.v1.StoreEvidenceResponse
-	(*StoreEvidencesResponse)(nil),            // 3: clouditor.evidence.v1.StoreEvidencesResponse
-	(*ListEvidencesRequest)(nil),              // 4: clouditor.evidence.v1.ListEvidencesRequest
-	(*Filter)(nil),                            // 5: clouditor.evidence.v1.Filter
-	(*ListEvidencesResponse)(nil),             // 6: clouditor.evidence.v1.ListEvidencesResponse
-	(*GetEvidenceRequest)(nil),                // 7: clouditor.evidence.v1.GetEvidenceRequest
-	(*GetSupportedResourceTypesRequest)(nil),  // 8: clouditor.evidence.v1.GetSupportedResourceTypesRequest
-	(*GetSupportedResourceTypesResponse)(nil), // 9: clouditor.evidence.v1.GetSupportedResourceTypesResponse
-	(*Evidence)(nil),                          // 10: clouditor.evidence.v1.Evidence
+	(EvidenceStatus)(0),                        // 0: clouditor.evidence.v1.EvidenceStatus
+	(*StoreEvidenceRequest)(nil),               // 1: clouditor.evidence.v1.StoreEvidenceRequest
+	(*StoreEvidenceResponse)(nil),              // 2: clouditor.evidence.v1.StoreEvidenceResponse
+	(*StoreEvidencesResponse)(nil),             // 3: clouditor.evidence.v1.StoreEvidencesResponse
+	(*ListEvidencesRequest)(nil),               // 4: clouditor.evidence.v1.ListEvidencesRequest
+	(*Filter)(nil),                             // 5: clouditor.evidence.v1.Filter
+	(*ListEvidencesResponse)(nil),              // 6: clouditor.evidence.v1.ListEvidencesResponse
+	(*GetEvidenceRequest)(nil),                 // 7: clouditor.evidence.v1.GetEvidenceRequest
+	(*ListSupportedResourceTypesRequest)(nil),  // 8: clouditor.evidence.v1.ListSupportedResourceTypesRequest
+	(*ListSupportedResourceTypesResponse)(nil), // 9: clouditor.evidence.v1.ListSupportedResourceTypesResponse
+	(*Evidence)(nil),                           // 10: clouditor.evidence.v1.Evidence
 }
 var file_api_evidence_evidence_store_proto_depIdxs = []int32{
 	10, // 0: clouditor.evidence.v1.StoreEvidenceRequest.evidence:type_name -> clouditor.evidence.v1.Evidence
@@ -629,12 +630,12 @@ var file_api_evidence_evidence_store_proto_depIdxs = []int32{
 	1,  // 6: clouditor.evidence.v1.EvidenceStore.StoreEvidences:input_type -> clouditor.evidence.v1.StoreEvidenceRequest
 	4,  // 7: clouditor.evidence.v1.EvidenceStore.ListEvidences:input_type -> clouditor.evidence.v1.ListEvidencesRequest
 	7,  // 8: clouditor.evidence.v1.EvidenceStore.GetEvidence:input_type -> clouditor.evidence.v1.GetEvidenceRequest
-	8,  // 9: clouditor.evidence.v1.EvidenceStore.GetSupportedResourceTypes:input_type -> clouditor.evidence.v1.GetSupportedResourceTypesRequest
+	8,  // 9: clouditor.evidence.v1.EvidenceStore.ListSupportedResourceTypes:input_type -> clouditor.evidence.v1.ListSupportedResourceTypesRequest
 	2,  // 10: clouditor.evidence.v1.EvidenceStore.StoreEvidence:output_type -> clouditor.evidence.v1.StoreEvidenceResponse
 	3,  // 11: clouditor.evidence.v1.EvidenceStore.StoreEvidences:output_type -> clouditor.evidence.v1.StoreEvidencesResponse
 	6,  // 12: clouditor.evidence.v1.EvidenceStore.ListEvidences:output_type -> clouditor.evidence.v1.ListEvidencesResponse
 	10, // 13: clouditor.evidence.v1.EvidenceStore.GetEvidence:output_type -> clouditor.evidence.v1.Evidence
-	9,  // 14: clouditor.evidence.v1.EvidenceStore.GetSupportedResourceTypes:output_type -> clouditor.evidence.v1.GetSupportedResourceTypesResponse
+	9,  // 14: clouditor.evidence.v1.EvidenceStore.ListSupportedResourceTypes:output_type -> clouditor.evidence.v1.ListSupportedResourceTypesResponse
 	10, // [10:15] is the sub-list for method output_type
 	5,  // [5:10] is the sub-list for method input_type
 	5,  // [5:5] is the sub-list for extension type_name

--- a/api/evidence/evidence_store.pb.gw.go
+++ b/api/evidence/evidence_store.pb.gw.go
@@ -43,6 +43,9 @@ func request_EvidenceStore_StoreEvidence_0(ctx context.Context, marshaler runtim
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Evidence); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.StoreEvidence(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -66,7 +69,9 @@ func request_EvidenceStore_ListEvidences_0(ctx context.Context, marshaler runtim
 		protoReq ListEvidencesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -98,7 +103,9 @@ func request_EvidenceStore_GetEvidence_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["evidence_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "evidence_id")
@@ -129,22 +136,24 @@ func local_request_EvidenceStore_GetEvidence_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
-func request_EvidenceStore_GetSupportedResourceTypes_0(ctx context.Context, marshaler runtime.Marshaler, client EvidenceStoreClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_EvidenceStore_ListSupportedResourceTypes_0(ctx context.Context, marshaler runtime.Marshaler, client EvidenceStoreClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq GetSupportedResourceTypesRequest
+		protoReq ListSupportedResourceTypesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
-	msg, err := client.GetSupportedResourceTypes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListSupportedResourceTypes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_EvidenceStore_GetSupportedResourceTypes_0(ctx context.Context, marshaler runtime.Marshaler, server EvidenceStoreServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_EvidenceStore_ListSupportedResourceTypes_0(ctx context.Context, marshaler runtime.Marshaler, server EvidenceStoreServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq GetSupportedResourceTypesRequest
+		protoReq ListSupportedResourceTypesRequest
 		metadata runtime.ServerMetadata
 	)
-	msg, err := server.GetSupportedResourceTypes(ctx, &protoReq)
+	msg, err := server.ListSupportedResourceTypes(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -214,25 +223,25 @@ func RegisterEvidenceStoreHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_EvidenceStore_GetEvidence_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_EvidenceStore_GetSupportedResourceTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_EvidenceStore_ListSupportedResourceTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/clouditor.evidence.v1.EvidenceStore/GetSupportedResourceTypes", runtime.WithHTTPPathPattern("/v1/evidence_store/supported_resource_types"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/clouditor.evidence.v1.EvidenceStore/ListSupportedResourceTypes", runtime.WithHTTPPathPattern("/v1/evidence_store/supported_resource_types"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_EvidenceStore_ListSupportedResourceTypes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_EvidenceStore_ListSupportedResourceTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -325,36 +334,36 @@ func RegisterEvidenceStoreHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_EvidenceStore_GetEvidence_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_EvidenceStore_GetSupportedResourceTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_EvidenceStore_ListSupportedResourceTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/clouditor.evidence.v1.EvidenceStore/GetSupportedResourceTypes", runtime.WithHTTPPathPattern("/v1/evidence_store/supported_resource_types"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/clouditor.evidence.v1.EvidenceStore/ListSupportedResourceTypes", runtime.WithHTTPPathPattern("/v1/evidence_store/supported_resource_types"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_EvidenceStore_ListSupportedResourceTypes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_EvidenceStore_ListSupportedResourceTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	return nil
 }
 
 var (
-	pattern_EvidenceStore_StoreEvidence_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidence"}, ""))
-	pattern_EvidenceStore_ListEvidences_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidences"}, ""))
-	pattern_EvidenceStore_GetEvidence_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "evidence_store", "evidences", "evidence_id"}, ""))
-	pattern_EvidenceStore_GetSupportedResourceTypes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "supported_resource_types"}, ""))
+	pattern_EvidenceStore_StoreEvidence_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidence"}, ""))
+	pattern_EvidenceStore_ListEvidences_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidences"}, ""))
+	pattern_EvidenceStore_GetEvidence_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "evidence_store", "evidences", "evidence_id"}, ""))
+	pattern_EvidenceStore_ListSupportedResourceTypes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "supported_resource_types"}, ""))
 )
 
 var (
-	forward_EvidenceStore_StoreEvidence_0             = runtime.ForwardResponseMessage
-	forward_EvidenceStore_ListEvidences_0             = runtime.ForwardResponseMessage
-	forward_EvidenceStore_GetEvidence_0               = runtime.ForwardResponseMessage
-	forward_EvidenceStore_GetSupportedResourceTypes_0 = runtime.ForwardResponseMessage
+	forward_EvidenceStore_StoreEvidence_0              = runtime.ForwardResponseMessage
+	forward_EvidenceStore_ListEvidences_0              = runtime.ForwardResponseMessage
+	forward_EvidenceStore_GetEvidence_0                = runtime.ForwardResponseMessage
+	forward_EvidenceStore_ListSupportedResourceTypes_0 = runtime.ForwardResponseMessage
 )

--- a/api/evidence/evidence_store.pb.gw.go
+++ b/api/evidence/evidence_store.pb.gw.go
@@ -129,6 +129,25 @@ func local_request_EvidenceStore_GetEvidence_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+func request_EvidenceStore_GetSupportedResourceTypes_0(ctx context.Context, marshaler runtime.Marshaler, client EvidenceStoreClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetSupportedResourceTypesRequest
+		metadata runtime.ServerMetadata
+	)
+	io.Copy(io.Discard, req.Body)
+	msg, err := client.GetSupportedResourceTypes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_EvidenceStore_GetSupportedResourceTypes_0(ctx context.Context, marshaler runtime.Marshaler, server EvidenceStoreServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetSupportedResourceTypesRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetSupportedResourceTypes(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterEvidenceStoreHandlerServer registers the http handlers for service EvidenceStore to "mux".
 // UnaryRPC     :call EvidenceStoreServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -194,6 +213,26 @@ func RegisterEvidenceStoreHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_EvidenceStore_GetEvidence_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_EvidenceStore_GetSupportedResourceTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/clouditor.evidence.v1.EvidenceStore/GetSupportedResourceTypes", runtime.WithHTTPPathPattern("/v1/evidence_store/supported_resource_types"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -286,17 +325,36 @@ func RegisterEvidenceStoreHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_EvidenceStore_GetEvidence_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_EvidenceStore_GetSupportedResourceTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/clouditor.evidence.v1.EvidenceStore/GetSupportedResourceTypes", runtime.WithHTTPPathPattern("/v1/evidence_store/supported_resource_types"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_EvidenceStore_GetSupportedResourceTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_EvidenceStore_StoreEvidence_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidence"}, ""))
-	pattern_EvidenceStore_ListEvidences_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidences"}, ""))
-	pattern_EvidenceStore_GetEvidence_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "evidence_store", "evidences", "evidence_id"}, ""))
+	pattern_EvidenceStore_StoreEvidence_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidence"}, ""))
+	pattern_EvidenceStore_ListEvidences_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "evidences"}, ""))
+	pattern_EvidenceStore_GetEvidence_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "evidence_store", "evidences", "evidence_id"}, ""))
+	pattern_EvidenceStore_GetSupportedResourceTypes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "evidence_store", "supported_resource_types"}, ""))
 )
 
 var (
-	forward_EvidenceStore_StoreEvidence_0 = runtime.ForwardResponseMessage
-	forward_EvidenceStore_ListEvidences_0 = runtime.ForwardResponseMessage
-	forward_EvidenceStore_GetEvidence_0   = runtime.ForwardResponseMessage
+	forward_EvidenceStore_StoreEvidence_0             = runtime.ForwardResponseMessage
+	forward_EvidenceStore_ListEvidences_0             = runtime.ForwardResponseMessage
+	forward_EvidenceStore_GetEvidence_0               = runtime.ForwardResponseMessage
+	forward_EvidenceStore_GetSupportedResourceTypes_0 = runtime.ForwardResponseMessage
 )

--- a/api/evidence/evidence_store.proto
+++ b/api/evidence/evidence_store.proto
@@ -114,5 +114,5 @@ message GetEvidenceRequest {
 message GetSupportedResourceTypesRequest {}
 
 message GetSupportedResourceTypesResponse {
-  repeated string resource_types = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated string resource_type = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/api/evidence/evidence_store.proto
+++ b/api/evidence/evidence_store.proto
@@ -60,7 +60,7 @@ service EvidenceStore {
   }
 
   // Returns the resource types that are supported by the EvidenceStore.
-  rpc GetSupportedResourceTypes(GetSupportedResourceTypesRequest) returns (GetSupportedResourceTypesResponse) {
+  rpc ListSupportedResourceTypes(ListSupportedResourceTypesRequest) returns (ListSupportedResourceTypesResponse) {
     option (google.api.http) = {get: "/v1/evidence_store/supported_resource_types"};
   }
 }
@@ -111,8 +111,8 @@ message GetEvidenceRequest {
   string evidence_id = 1 [(buf.validate.field).string.uuid = true];
 }
 
-message GetSupportedResourceTypesRequest {}
+message ListSupportedResourceTypesRequest {}
 
-message GetSupportedResourceTypesResponse {
+message ListSupportedResourceTypesResponse {
   repeated string resource_type = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/api/evidence/evidence_store.proto
+++ b/api/evidence/evidence_store.proto
@@ -58,6 +58,11 @@ service EvidenceStore {
   rpc GetEvidence(GetEvidenceRequest) returns (Evidence) {
     option (google.api.http) = {get: "/v1/evidence_store/evidences/{evidence_id}"};
   }
+
+  // Returns the resource types that are supported by the EvidenceStore.
+  rpc GetSupportedResourceTypes(GetSupportedResourceTypesRequest) returns (GetSupportedResourceTypesResponse) {
+    option (google.api.http) = {get: "/v1/evidence_store/supported_resource_types"};
+  }
 }
 
 message StoreEvidenceRequest {
@@ -104,4 +109,10 @@ message ListEvidencesResponse {
 
 message GetEvidenceRequest {
   string evidence_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+message GetSupportedResourceTypesRequest {}
+
+message GetSupportedResourceTypesResponse {
+  repeated string resource_types = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/api/evidence/evidence_store_grpc.pb.go
+++ b/api/evidence/evidence_store_grpc.pb.go
@@ -44,10 +44,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	EvidenceStore_StoreEvidence_FullMethodName  = "/clouditor.evidence.v1.EvidenceStore/StoreEvidence"
-	EvidenceStore_StoreEvidences_FullMethodName = "/clouditor.evidence.v1.EvidenceStore/StoreEvidences"
-	EvidenceStore_ListEvidences_FullMethodName  = "/clouditor.evidence.v1.EvidenceStore/ListEvidences"
-	EvidenceStore_GetEvidence_FullMethodName    = "/clouditor.evidence.v1.EvidenceStore/GetEvidence"
+	EvidenceStore_StoreEvidence_FullMethodName             = "/clouditor.evidence.v1.EvidenceStore/StoreEvidence"
+	EvidenceStore_StoreEvidences_FullMethodName            = "/clouditor.evidence.v1.EvidenceStore/StoreEvidences"
+	EvidenceStore_ListEvidences_FullMethodName             = "/clouditor.evidence.v1.EvidenceStore/ListEvidences"
+	EvidenceStore_GetEvidence_FullMethodName               = "/clouditor.evidence.v1.EvidenceStore/GetEvidence"
+	EvidenceStore_GetSupportedResourceTypes_FullMethodName = "/clouditor.evidence.v1.EvidenceStore/GetSupportedResourceTypes"
 )
 
 // EvidenceStoreClient is the client API for EvidenceStore service.
@@ -67,6 +68,8 @@ type EvidenceStoreClient interface {
 	// Returns a particular stored evidence. Part of the public API, also exposed
 	// as REST.
 	GetEvidence(ctx context.Context, in *GetEvidenceRequest, opts ...grpc.CallOption) (*Evidence, error)
+	// Returns the resource types that are supported by the EvidenceStore.
+	GetSupportedResourceTypes(ctx context.Context, in *GetSupportedResourceTypesRequest, opts ...grpc.CallOption) (*GetSupportedResourceTypesResponse, error)
 }
 
 type evidenceStoreClient struct {
@@ -120,6 +123,16 @@ func (c *evidenceStoreClient) GetEvidence(ctx context.Context, in *GetEvidenceRe
 	return out, nil
 }
 
+func (c *evidenceStoreClient) GetSupportedResourceTypes(ctx context.Context, in *GetSupportedResourceTypesRequest, opts ...grpc.CallOption) (*GetSupportedResourceTypesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSupportedResourceTypesResponse)
+	err := c.cc.Invoke(ctx, EvidenceStore_GetSupportedResourceTypes_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // EvidenceStoreServer is the server API for EvidenceStore service.
 // All implementations must embed UnimplementedEvidenceStoreServer
 // for forward compatibility.
@@ -137,6 +150,8 @@ type EvidenceStoreServer interface {
 	// Returns a particular stored evidence. Part of the public API, also exposed
 	// as REST.
 	GetEvidence(context.Context, *GetEvidenceRequest) (*Evidence, error)
+	// Returns the resource types that are supported by the EvidenceStore.
+	GetSupportedResourceTypes(context.Context, *GetSupportedResourceTypesRequest) (*GetSupportedResourceTypesResponse, error)
 	mustEmbedUnimplementedEvidenceStoreServer()
 }
 
@@ -158,6 +173,9 @@ func (UnimplementedEvidenceStoreServer) ListEvidences(context.Context, *ListEvid
 }
 func (UnimplementedEvidenceStoreServer) GetEvidence(context.Context, *GetEvidenceRequest) (*Evidence, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEvidence not implemented")
+}
+func (UnimplementedEvidenceStoreServer) GetSupportedResourceTypes(context.Context, *GetSupportedResourceTypesRequest) (*GetSupportedResourceTypesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSupportedResourceTypes not implemented")
 }
 func (UnimplementedEvidenceStoreServer) mustEmbedUnimplementedEvidenceStoreServer() {}
 func (UnimplementedEvidenceStoreServer) testEmbeddedByValue()                       {}
@@ -241,6 +259,24 @@ func _EvidenceStore_GetEvidence_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EvidenceStore_GetSupportedResourceTypes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSupportedResourceTypesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EvidenceStoreServer).GetSupportedResourceTypes(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EvidenceStore_GetSupportedResourceTypes_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EvidenceStoreServer).GetSupportedResourceTypes(ctx, req.(*GetSupportedResourceTypesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // EvidenceStore_ServiceDesc is the grpc.ServiceDesc for EvidenceStore service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -259,6 +295,10 @@ var EvidenceStore_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetEvidence",
 			Handler:    _EvidenceStore_GetEvidence_Handler,
+		},
+		{
+			MethodName: "GetSupportedResourceTypes",
+			Handler:    _EvidenceStore_GetSupportedResourceTypes_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/api/evidence/evidence_store_grpc.pb.go
+++ b/api/evidence/evidence_store_grpc.pb.go
@@ -33,6 +33,7 @@ package evidence
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -44,11 +45,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	EvidenceStore_StoreEvidence_FullMethodName             = "/clouditor.evidence.v1.EvidenceStore/StoreEvidence"
-	EvidenceStore_StoreEvidences_FullMethodName            = "/clouditor.evidence.v1.EvidenceStore/StoreEvidences"
-	EvidenceStore_ListEvidences_FullMethodName             = "/clouditor.evidence.v1.EvidenceStore/ListEvidences"
-	EvidenceStore_GetEvidence_FullMethodName               = "/clouditor.evidence.v1.EvidenceStore/GetEvidence"
-	EvidenceStore_GetSupportedResourceTypes_FullMethodName = "/clouditor.evidence.v1.EvidenceStore/GetSupportedResourceTypes"
+	EvidenceStore_StoreEvidence_FullMethodName              = "/clouditor.evidence.v1.EvidenceStore/StoreEvidence"
+	EvidenceStore_StoreEvidences_FullMethodName             = "/clouditor.evidence.v1.EvidenceStore/StoreEvidences"
+	EvidenceStore_ListEvidences_FullMethodName              = "/clouditor.evidence.v1.EvidenceStore/ListEvidences"
+	EvidenceStore_GetEvidence_FullMethodName                = "/clouditor.evidence.v1.EvidenceStore/GetEvidence"
+	EvidenceStore_ListSupportedResourceTypes_FullMethodName = "/clouditor.evidence.v1.EvidenceStore/ListSupportedResourceTypes"
 )
 
 // EvidenceStoreClient is the client API for EvidenceStore service.
@@ -69,7 +70,7 @@ type EvidenceStoreClient interface {
 	// as REST.
 	GetEvidence(ctx context.Context, in *GetEvidenceRequest, opts ...grpc.CallOption) (*Evidence, error)
 	// Returns the resource types that are supported by the EvidenceStore.
-	GetSupportedResourceTypes(ctx context.Context, in *GetSupportedResourceTypesRequest, opts ...grpc.CallOption) (*GetSupportedResourceTypesResponse, error)
+	ListSupportedResourceTypes(ctx context.Context, in *ListSupportedResourceTypesRequest, opts ...grpc.CallOption) (*ListSupportedResourceTypesResponse, error)
 }
 
 type evidenceStoreClient struct {
@@ -123,10 +124,10 @@ func (c *evidenceStoreClient) GetEvidence(ctx context.Context, in *GetEvidenceRe
 	return out, nil
 }
 
-func (c *evidenceStoreClient) GetSupportedResourceTypes(ctx context.Context, in *GetSupportedResourceTypesRequest, opts ...grpc.CallOption) (*GetSupportedResourceTypesResponse, error) {
+func (c *evidenceStoreClient) ListSupportedResourceTypes(ctx context.Context, in *ListSupportedResourceTypesRequest, opts ...grpc.CallOption) (*ListSupportedResourceTypesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GetSupportedResourceTypesResponse)
-	err := c.cc.Invoke(ctx, EvidenceStore_GetSupportedResourceTypes_FullMethodName, in, out, cOpts...)
+	out := new(ListSupportedResourceTypesResponse)
+	err := c.cc.Invoke(ctx, EvidenceStore_ListSupportedResourceTypes_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ type EvidenceStoreServer interface {
 	// as REST.
 	GetEvidence(context.Context, *GetEvidenceRequest) (*Evidence, error)
 	// Returns the resource types that are supported by the EvidenceStore.
-	GetSupportedResourceTypes(context.Context, *GetSupportedResourceTypesRequest) (*GetSupportedResourceTypesResponse, error)
+	ListSupportedResourceTypes(context.Context, *ListSupportedResourceTypesRequest) (*ListSupportedResourceTypesResponse, error)
 	mustEmbedUnimplementedEvidenceStoreServer()
 }
 
@@ -174,8 +175,8 @@ func (UnimplementedEvidenceStoreServer) ListEvidences(context.Context, *ListEvid
 func (UnimplementedEvidenceStoreServer) GetEvidence(context.Context, *GetEvidenceRequest) (*Evidence, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEvidence not implemented")
 }
-func (UnimplementedEvidenceStoreServer) GetSupportedResourceTypes(context.Context, *GetSupportedResourceTypesRequest) (*GetSupportedResourceTypesResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetSupportedResourceTypes not implemented")
+func (UnimplementedEvidenceStoreServer) ListSupportedResourceTypes(context.Context, *ListSupportedResourceTypesRequest) (*ListSupportedResourceTypesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSupportedResourceTypes not implemented")
 }
 func (UnimplementedEvidenceStoreServer) mustEmbedUnimplementedEvidenceStoreServer() {}
 func (UnimplementedEvidenceStoreServer) testEmbeddedByValue()                       {}
@@ -259,20 +260,20 @@ func _EvidenceStore_GetEvidence_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
-func _EvidenceStore_GetSupportedResourceTypes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetSupportedResourceTypesRequest)
+func _EvidenceStore_ListSupportedResourceTypes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSupportedResourceTypesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(EvidenceStoreServer).GetSupportedResourceTypes(ctx, in)
+		return srv.(EvidenceStoreServer).ListSupportedResourceTypes(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: EvidenceStore_GetSupportedResourceTypes_FullMethodName,
+		FullMethod: EvidenceStore_ListSupportedResourceTypes_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(EvidenceStoreServer).GetSupportedResourceTypes(ctx, req.(*GetSupportedResourceTypesRequest))
+		return srv.(EvidenceStoreServer).ListSupportedResourceTypes(ctx, req.(*ListSupportedResourceTypesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -297,8 +298,8 @@ var EvidenceStore_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _EvidenceStore_GetEvidence_Handler,
 		},
 		{
-			MethodName: "GetSupportedResourceTypes",
-			Handler:    _EvidenceStore_GetSupportedResourceTypes_Handler,
+			MethodName: "ListSupportedResourceTypes",
+			Handler:    _EvidenceStore_ListSupportedResourceTypes_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/api/ontology/ontology.go
+++ b/api/ontology/ontology.go
@@ -88,8 +88,8 @@ func ResourceTypes(r IsResource) []string {
 	return nil
 }
 
-// GetResourceTypes returns a list of resource types that are supported by the ontology.
-func GetResourceTypes() []string {
+// ListResourceTypes returns a list of resource types that are supported by the ontology.
+func ListResourceTypes() []string {
 	var types []string
 
 	var resource Resource

--- a/api/ontology/ontology.go
+++ b/api/ontology/ontology.go
@@ -88,6 +88,43 @@ func ResourceTypes(r IsResource) []string {
 	return nil
 }
 
+// GetResourceTypes returns a list of resource types that are supported by the ontology.
+func GetResourceTypes() []string {
+	var types []string
+
+	var resource Resource
+
+	// Zugriff auf die Descriptor der Resource-Message
+	md := resource.ProtoReflect().Descriptor()
+
+	// Durchlaufen der Felder der Resource
+	for i := 0; i < md.Fields().Len(); i++ {
+		field := md.Fields().Get(i)
+		if field.ContainingOneof() != nil {
+			types = append(types, string(field.Name()))
+		}
+	}
+
+	return types
+}
+
+// func GetResourceTypes() []string {
+// 	var types []string
+// 	resource := &ontology.Resource{}
+// 	// rt := reflect.TypeOf(resourceType)
+
+// 	md := proto.MessageReflect(resource).Descriptor()
+
+// 	for i := 0; i < md.Fields().Len(); i++ {
+// 		field := md.Fields().Get(i)
+// 		if field.ContainingOneof() != nil {
+// 			types = append(types, string(field.Name()))
+// 		}
+// 	}
+
+// 	return types
+// }
+
 func HasType(r IsResource, typ string) bool {
 	return slices.Contains(ResourceTypes(r), typ)
 }

--- a/api/ontology/ontology.go
+++ b/api/ontology/ontology.go
@@ -97,7 +97,7 @@ func GetResourceTypes() []string {
 	// Accessing the descriptor of the resource message.
 	md := resource.ProtoReflect().Descriptor()
 
-	// Durchlaufen der Felder der Resource
+	// Collect the names of all fields that belong to the oneOf field.
 	for i := 0; i < md.Fields().Len(); i++ {
 		field := md.Fields().Get(i)
 		if field.ContainingOneof() != nil {

--- a/api/ontology/ontology.go
+++ b/api/ontology/ontology.go
@@ -94,7 +94,7 @@ func GetResourceTypes() []string {
 
 	var resource Resource
 
-	// Zugriff auf die Descriptor der Resource-Message
+	// Accessing the descriptor of the resource message.
 	md := resource.ProtoReflect().Descriptor()
 
 	// Durchlaufen der Felder der Resource
@@ -107,23 +107,6 @@ func GetResourceTypes() []string {
 
 	return types
 }
-
-// func GetResourceTypes() []string {
-// 	var types []string
-// 	resource := &ontology.Resource{}
-// 	// rt := reflect.TypeOf(resourceType)
-
-// 	md := proto.MessageReflect(resource).Descriptor()
-
-// 	for i := 0; i < md.Fields().Len(); i++ {
-// 		field := md.Fields().Get(i)
-// 		if field.ContainingOneof() != nil {
-// 			types = append(types, string(field.Name()))
-// 		}
-// 	}
-
-// 	return types
-// }
 
 func HasType(r IsResource, typ string) bool {
 	return slices.Contains(ResourceTypes(r), typ)

--- a/api/ontology/ontology_test.go
+++ b/api/ontology/ontology_test.go
@@ -229,7 +229,7 @@ func TestProtoResource(t *testing.T) {
 	}
 }
 
-func TestGetResourceTypes(t *testing.T) {
+func TestListResourceTypes(t *testing.T) {
 	tests := []struct {
 		name string
 		want assert.Want[[]string]
@@ -243,7 +243,7 @@ func TestGetResourceTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetResourceTypes()
+			got := ListResourceTypes()
 			tt.want(t, got)
 		})
 	}

--- a/api/ontology/ontology_test.go
+++ b/api/ontology/ontology_test.go
@@ -228,3 +228,23 @@ func TestProtoResource(t *testing.T) {
 		})
 	}
 }
+
+func TestGetResourceTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		want assert.Want[[]string]
+	}{
+		{
+			name: "Happy path",
+			want: func(t *testing.T, got []string) bool {
+				return assert.NotEmpty(t, got)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetResourceTypes()
+			tt.want(t, got)
+		})
+	}
+}

--- a/api/ontology/service.pb.gw.go
+++ b/api/ontology/service.pb.gw.go
@@ -43,6 +43,9 @@ func request_OntologyService_Noop_0(ctx context.Context, marshaler runtime.Marsh
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Resource); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.Noop(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }

--- a/api/orchestrator/orchestrator.pb.gw.go
+++ b/api/orchestrator/orchestrator.pb.gw.go
@@ -44,6 +44,9 @@ func request_Orchestrator_RegisterAssessmentTool_0(ctx context.Context, marshale
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Tool); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.RegisterAssessmentTool(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -67,7 +70,9 @@ func request_Orchestrator_ListAssessmentTools_0(ctx context.Context, marshaler r
 		protoReq ListAssessmentToolsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -99,7 +104,9 @@ func request_Orchestrator_GetAssessmentTool_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["tool_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "tool_id")
@@ -138,6 +145,9 @@ func request_Orchestrator_UpdateAssessmentTool_0(ctx context.Context, marshaler 
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Tool); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["tool.id"]
 	if !ok {
@@ -178,7 +188,9 @@ func request_Orchestrator_DeregisterAssessmentTool_0(ctx context.Context, marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["tool_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "tool_id")
@@ -217,6 +229,9 @@ func request_Orchestrator_StoreAssessmentResult_0(ctx context.Context, marshaler
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Result); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.StoreAssessmentResult(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -239,7 +254,9 @@ func request_Orchestrator_GetAssessmentResult_0(ctx context.Context, marshaler r
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -277,7 +294,9 @@ func request_Orchestrator_ListAssessmentResults_0(ctx context.Context, marshaler
 		protoReq ListAssessmentResultsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -311,6 +330,9 @@ func request_Orchestrator_CreateMetric_0(ctx context.Context, marshaler runtime.
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Metric); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateMetric(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -335,6 +357,9 @@ func request_Orchestrator_UpdateMetric_0(ctx context.Context, marshaler runtime.
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Metric); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["metric.id"]
 	if !ok {
@@ -375,7 +400,9 @@ func request_Orchestrator_GetMetric_0(ctx context.Context, marshaler runtime.Mar
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["metric_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "metric_id")
@@ -413,7 +440,9 @@ func request_Orchestrator_ListMetrics_0(ctx context.Context, marshaler runtime.M
 		protoReq ListMetricsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -445,7 +474,9 @@ func request_Orchestrator_RemoveMetric_0(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["metric_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "metric_id")
@@ -484,6 +515,9 @@ func request_Orchestrator_CreateTargetOfEvaluation_0(ctx context.Context, marsha
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.TargetOfEvaluation); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateTargetOfEvaluation(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -508,6 +542,9 @@ func request_Orchestrator_UpdateTargetOfEvaluation_0(ctx context.Context, marsha
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.TargetOfEvaluation); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["target_of_evaluation.id"]
 	if !ok {
@@ -548,7 +585,9 @@ func request_Orchestrator_GetTargetOfEvaluation_0(ctx context.Context, marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["target_of_evaluation_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "target_of_evaluation_id")
@@ -586,7 +625,9 @@ func request_Orchestrator_ListTargetsOfEvaluation_0(ctx context.Context, marshal
 		protoReq ListTargetsOfEvaluationRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -618,7 +659,9 @@ func request_Orchestrator_RemoveTargetOfEvaluation_0(ctx context.Context, marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["target_of_evaluation_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "target_of_evaluation_id")
@@ -656,7 +699,9 @@ func request_Orchestrator_GetTargetOfEvaluationStatistics_0(ctx context.Context,
 		protoReq GetTargetOfEvaluationStatisticsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -690,6 +735,9 @@ func request_Orchestrator_UpdateMetricConfiguration_0(ctx context.Context, marsh
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Configuration); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["target_of_evaluation_id"]
 	if !ok {
@@ -746,7 +794,9 @@ func request_Orchestrator_GetMetricConfiguration_0(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["target_of_evaluation_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "target_of_evaluation_id")
@@ -799,7 +849,9 @@ func request_Orchestrator_ListMetricConfigurations_0(ctx context.Context, marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["target_of_evaluation_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "target_of_evaluation_id")
@@ -838,6 +890,9 @@ func request_Orchestrator_UpdateMetricImplementation_0(ctx context.Context, mars
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Implementation); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["implementation.metric_id"]
 	if !ok {
@@ -878,7 +933,9 @@ func request_Orchestrator_GetMetricImplementation_0(ctx context.Context, marshal
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["metric_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "metric_id")
@@ -917,6 +974,9 @@ func request_Orchestrator_CreateCertificate_0(ctx context.Context, marshaler run
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Certificate); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateCertificate(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -939,7 +999,9 @@ func request_Orchestrator_GetCertificate_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["certificate_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "certificate_id")
@@ -977,7 +1039,9 @@ func request_Orchestrator_ListCertificates_0(ctx context.Context, marshaler runt
 		protoReq ListCertificatesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1010,7 +1074,9 @@ func request_Orchestrator_ListPublicCertificates_0(ctx context.Context, marshale
 		protoReq ListPublicCertificatesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1044,6 +1110,9 @@ func request_Orchestrator_UpdateCertificate_0(ctx context.Context, marshaler run
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Certificate); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["certificate.id"]
 	if !ok {
@@ -1084,7 +1153,9 @@ func request_Orchestrator_RemoveCertificate_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["certificate_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "certificate_id")
@@ -1123,6 +1194,9 @@ func request_Orchestrator_CreateCatalog_0(ctx context.Context, marshaler runtime
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Catalog); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateCatalog(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -1146,7 +1220,9 @@ func request_Orchestrator_ListCatalogs_0(ctx context.Context, marshaler runtime.
 		protoReq ListCatalogsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1178,7 +1254,9 @@ func request_Orchestrator_GetCatalog_0(ctx context.Context, marshaler runtime.Ma
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["catalog_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "catalog_id")
@@ -1215,7 +1293,9 @@ func request_Orchestrator_RemoveCatalog_0(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["catalog_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "catalog_id")
@@ -1254,6 +1334,9 @@ func request_Orchestrator_UpdateCatalog_0(ctx context.Context, marshaler runtime
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Catalog); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["catalog.id"]
 	if !ok {
@@ -1294,7 +1377,9 @@ func request_Orchestrator_GetCategory_0(ctx context.Context, marshaler runtime.M
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["catalog_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "catalog_id")
@@ -1348,7 +1433,9 @@ func request_Orchestrator_ListControls_0(ctx context.Context, marshaler runtime.
 		protoReq ListControlsRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1382,7 +1469,9 @@ func request_Orchestrator_ListControls_1(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["catalog_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "catalog_id")
@@ -1433,7 +1522,9 @@ func request_Orchestrator_ListControls_2(ctx context.Context, marshaler runtime.
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["catalog_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "catalog_id")
@@ -1498,7 +1589,9 @@ func request_Orchestrator_GetControl_0(ctx context.Context, marshaler runtime.Ma
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["catalog_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "catalog_id")
@@ -1569,6 +1662,9 @@ func request_Orchestrator_CreateAuditScope_0(ctx context.Context, marshaler runt
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.AuditScope); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.CreateAuditScope(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -1591,7 +1687,9 @@ func request_Orchestrator_GetAuditScope_0(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["audit_scope_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "audit_scope_id")
@@ -1629,7 +1727,9 @@ func request_Orchestrator_ListAuditScopes_0(ctx context.Context, marshaler runti
 		protoReq ListAuditScopesRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1663,6 +1763,9 @@ func request_Orchestrator_UpdateAuditScope_0(ctx context.Context, marshaler runt
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.AuditScope); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
 	}
 	val, ok := pathParams["audit_scope.target_of_evaluation_id"]
 	if !ok {
@@ -1721,7 +1824,9 @@ func request_Orchestrator_RemoveAuditScope_0(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	val, ok := pathParams["audit_scope_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "audit_scope_id")
@@ -1769,7 +1874,9 @@ func request_Orchestrator_GetRuntimeInfo_0(ctx context.Context, marshaler runtim
 		protoReq runtime_0.GetRuntimeInfoRequest
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
 	msg, err := client.GetRuntimeInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }

--- a/openapi/evidence/openapi.yaml
+++ b/openapi/evidence/openapi.yaml
@@ -107,6 +107,25 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /v1/evidence_store/supported_resource_types:
+        get:
+            tags:
+                - EvidenceStore
+            description: Returns the resource types that are supported by the EvidenceStore.
+            operationId: EvidenceStore_GetSupportedResourceTypes
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GetSupportedResourceTypesResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
         ABAC:
@@ -1396,6 +1415,13 @@ components:
                     items:
                         $ref: '#/components/schemas/GeoLocation'
             description: GeoRedundancy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
+        GetSupportedResourceTypesResponse:
+            type: object
+            properties:
+                resourceTypes:
+                    type: array
+                    items:
+                        type: string
         GoogleProtobufAny:
             type: object
             properties:

--- a/openapi/evidence/openapi.yaml
+++ b/openapi/evidence/openapi.yaml
@@ -112,14 +112,14 @@ paths:
             tags:
                 - EvidenceStore
             description: Returns the resource types that are supported by the EvidenceStore.
-            operationId: EvidenceStore_GetSupportedResourceTypes
+            operationId: EvidenceStore_ListSupportedResourceTypes
             responses:
                 "200":
                     description: OK
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/GetSupportedResourceTypesResponse'
+                                $ref: '#/components/schemas/ListSupportedResourceTypesResponse'
                 default:
                     description: Default error response
                     content:
@@ -1415,13 +1415,6 @@ components:
                     items:
                         $ref: '#/components/schemas/GeoLocation'
             description: GeoRedundancy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-        GetSupportedResourceTypesResponse:
-            type: object
-            properties:
-                resourceType:
-                    type: array
-                    items:
-                        type: string
         GoogleProtobufAny:
             type: object
             properties:
@@ -1791,6 +1784,13 @@ components:
                         $ref: '#/components/schemas/Evidence'
                 nextPageToken:
                     type: string
+        ListSupportedResourceTypesResponse:
+            type: object
+            properties:
+                resourceType:
+                    type: array
+                    items:
+                        type: string
         LoadBalancer:
             type: object
             properties:

--- a/openapi/evidence/openapi.yaml
+++ b/openapi/evidence/openapi.yaml
@@ -1418,7 +1418,7 @@ components:
         GetSupportedResourceTypesResponse:
             type: object
             properties:
-                resourceTypes:
+                resourceType:
                     type: array
                     items:
                         type: string

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -385,8 +385,8 @@ func (svc *Service) GetEvidence(ctx context.Context, req *evidence.GetEvidenceRe
 	return
 }
 
-// GetSupportedResourceTypes is a method implementation of the evidenceServer interface: It returns the resource types that are supported by this service
-func (svc *Service) GetSupportedResourceTypes(ctx context.Context, req *evidence.GetSupportedResourceTypesRequest) (res *evidence.GetSupportedResourceTypesResponse, err error) {
+// ListSupportedResourceTypes is a method implementation of the evidenceServer interface: It returns the resource types that are supported by this service
+func (svc *Service) ListSupportedResourceTypes(ctx context.Context, req *evidence.ListSupportedResourceTypesRequest) (res *evidence.ListSupportedResourceTypesResponse, err error) {
 	// Validate request
 	err = api.Validate(req)
 	if err != nil {
@@ -394,7 +394,7 @@ func (svc *Service) GetSupportedResourceTypes(ctx context.Context, req *evidence
 	}
 
 	// Get the supported resource types
-	res = &evidence.GetSupportedResourceTypesResponse{
+	res = &evidence.ListSupportedResourceTypesResponse{
 		ResourceType: ontology.GetResourceTypes(),
 	}
 

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -36,6 +36,7 @@ import (
 	"clouditor.io/clouditor/v2/api"
 	"clouditor.io/clouditor/v2/api/assessment"
 	"clouditor.io/clouditor/v2/api/evidence"
+	"clouditor.io/clouditor/v2/api/ontology"
 	"clouditor.io/clouditor/v2/internal/config"
 	"clouditor.io/clouditor/v2/internal/logging"
 	"clouditor.io/clouditor/v2/launcher"
@@ -382,6 +383,22 @@ func (svc *Service) GetEvidence(ctx context.Context, req *evidence.GetEvidenceRe
 	}
 
 	return
+}
+
+// GetSupportedResourceTypes is a method implementation of the evidenceServer interface: It returns the resource types that are supported by this service
+func (svc *Service) GetSupportedResourceTypes(ctx context.Context, req *evidence.GetSupportedResourceTypesRequest) (res *evidence.GetSupportedResourceTypesResponse, err error) {
+	// Validate request
+	err = api.Validate(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the supported resource types
+	res = &evidence.GetSupportedResourceTypesResponse{
+		ResourceTypes: ontology.GetResourceTypes(),
+	}
+
+	return res, nil
 }
 
 func (svc *Service) RegisterEvidenceHook(evidenceHook evidence.EvidenceHookFunc) {

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -395,7 +395,7 @@ func (svc *Service) ListSupportedResourceTypes(ctx context.Context, req *evidenc
 
 	// Get the supported resource types
 	res = &evidence.ListSupportedResourceTypesResponse{
-		ResourceType: ontology.GetResourceTypes(),
+		ResourceType: ontology.ListResourceTypes(),
 	}
 
 	return res, nil

--- a/service/evidence/evidence_store.go
+++ b/service/evidence/evidence_store.go
@@ -395,7 +395,7 @@ func (svc *Service) GetSupportedResourceTypes(ctx context.Context, req *evidence
 
 	// Get the supported resource types
 	res = &evidence.GetSupportedResourceTypesResponse{
-		ResourceTypes: ontology.GetResourceTypes(),
+		ResourceType: ontology.GetResourceTypes(),
 	}
 
 	return res, nil

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -50,7 +50,6 @@ import (
 	"clouditor.io/clouditor/v2/persistence"
 	"clouditor.io/clouditor/v2/persistence/gorm"
 	"clouditor.io/clouditor/v2/service"
-
 	"github.com/google/uuid"
 	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc"

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -1324,7 +1324,7 @@ func TestService_GetSupportedResourceTypes(t *testing.T) {
 			},
 			wantRes: func(t *testing.T, got *evidence.GetSupportedResourceTypesResponse) bool {
 				assert.NotNil(t, got)
-				return assert.NotEmpty(t, got.ResourceTypes)
+				return assert.NotEmpty(t, got.ResourceType)
 			},
 			wantErr: assert.NoError,
 		},

--- a/service/evidence/evidence_store_test.go
+++ b/service/evidence/evidence_store_test.go
@@ -1283,7 +1283,7 @@ func TestService_handleEvidence(t *testing.T) {
 	}
 }
 
-func TestService_GetSupportedResourceTypes(t *testing.T) {
+func TestService_ListSupportedResourceTypes(t *testing.T) {
 	type fields struct {
 		storage                          persistence.Storage
 		assessmentStreams                *api.StreamsOf[assessment.Assessment_AssessEvidencesClient, *assessment.AssessEvidenceRequest]
@@ -1295,13 +1295,13 @@ func TestService_GetSupportedResourceTypes(t *testing.T) {
 	}
 	type args struct {
 		ctx context.Context
-		req *evidence.GetSupportedResourceTypesRequest
+		req *evidence.ListSupportedResourceTypesRequest
 	}
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		wantRes assert.Want[*evidence.GetSupportedResourceTypesResponse]
+		wantRes assert.Want[*evidence.ListSupportedResourceTypesResponse]
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -1310,7 +1310,7 @@ func TestService_GetSupportedResourceTypes(t *testing.T) {
 				ctx: context.TODO(),
 				req: nil,
 			},
-			wantRes: assert.Nil[*evidence.GetSupportedResourceTypesResponse],
+			wantRes: assert.Nil[*evidence.ListSupportedResourceTypesResponse],
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				assert.ErrorContains(t, err, api.ErrEmptyRequest.Error())
 				return assert.Equal(t, status.Code(err), codes.InvalidArgument)
@@ -1320,9 +1320,9 @@ func TestService_GetSupportedResourceTypes(t *testing.T) {
 			name: "Happy path",
 			args: args{
 				ctx: context.TODO(),
-				req: &evidence.GetSupportedResourceTypesRequest{},
+				req: &evidence.ListSupportedResourceTypesRequest{},
 			},
-			wantRes: func(t *testing.T, got *evidence.GetSupportedResourceTypesResponse) bool {
+			wantRes: func(t *testing.T, got *evidence.ListSupportedResourceTypesResponse) bool {
 				assert.NotNil(t, got)
 				return assert.NotEmpty(t, got.ResourceType)
 			},
@@ -1339,7 +1339,7 @@ func TestService_GetSupportedResourceTypes(t *testing.T) {
 				evidenceHooks:     tt.fields.evidenceHooks,
 				authz:             tt.fields.authz,
 			}
-			gotRes, err := svc.GetSupportedResourceTypes(tt.args.ctx, tt.args.req)
+			gotRes, err := svc.ListSupportedResourceTypes(tt.args.ctx, tt.args.req)
 
 			tt.wantRes(t, gotRes)
 			tt.wantErr(t, err)


### PR DESCRIPTION
This PR adds an additional endpoint to the EvidenceStore to get the supported Ontology `resource` types.